### PR TITLE
fix(tools): resolve PHPStan type compatibility and asset permissions

### DIFF
--- a/src/Mcp/Tools/BaseRouter.php
+++ b/src/Mcp/Tools/BaseRouter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Cboxdk\StatamicMcp\Mcp\Tools;
 
+use Illuminate\Contracts\JsonSchema\JsonSchema as JsonSchemaContract;
 use Illuminate\JsonSchema\JsonSchema;
 
 /**
@@ -62,7 +63,7 @@ abstract class BaseRouter extends BaseStatamicTool
         return "Manage Statamic {$domain}: {$actionList}. Use action='help' for detailed guidance.";
     }
 
-    protected function defineSchema(JsonSchema $schema): array
+    protected function defineSchema(JsonSchemaContract $schema): array
     {
         $actions = array_keys($this->getActions());
         $actions[] = 'help';

--- a/src/Mcp/Tools/BaseStatamicTool.php
+++ b/src/Mcp/Tools/BaseStatamicTool.php
@@ -8,6 +8,7 @@ use Cboxdk\StatamicMcp\Mcp\DataTransferObjects\SuccessResponse;
 use Cboxdk\StatamicMcp\Mcp\Support\ErrorCodes;
 use Cboxdk\StatamicMcp\Mcp\Support\ToolLogger;
 use Cboxdk\StatamicMcp\Mcp\Support\ToolResponse;
+use Illuminate\Contracts\JsonSchema\JsonSchema as JsonSchemaContract;
 use Illuminate\JsonSchema\JsonSchema;
 use Laravel\Mcp\Server\Tool;
 
@@ -28,7 +29,7 @@ abstract class BaseStatamicTool extends Tool
      *
      * @return array<string, mixed>
      */
-    abstract protected function defineSchema(JsonSchema $schema): array;
+    abstract protected function defineSchema(JsonSchemaContract $schema): array;
 
     /**
      * Execute the tool logic.
@@ -60,7 +61,7 @@ abstract class BaseStatamicTool extends Tool
      *
      * @return array<string, mixed>
      */
-    final public function schema(JsonSchema $schema): array
+    final public function schema(JsonSchemaContract $schema): array
     {
         return $this->defineSchema($schema);
     }

--- a/src/Mcp/Tools/Routers/AssetsRouter.php
+++ b/src/Mcp/Tools/Routers/AssetsRouter.php
@@ -7,6 +7,7 @@ namespace Cboxdk\StatamicMcp\Mcp\Tools\Routers;
 use Cboxdk\StatamicMcp\Mcp\Tools\BaseRouter;
 use Cboxdk\StatamicMcp\Mcp\Tools\Concerns\ExecutesWithAudit;
 use Cboxdk\StatamicMcp\Mcp\Tools\Concerns\RouterHelpers;
+use Illuminate\Contracts\JsonSchema\JsonSchema as JsonSchemaContract;
 use Illuminate\JsonSchema\JsonSchema;
 use Statamic\Facades\Asset;
 use Statamic\Facades\AssetContainer;
@@ -120,7 +121,7 @@ class AssetsRouter extends BaseRouter
         ];
     }
 
-    protected function defineSchema(JsonSchema $schema): array
+    protected function defineSchema(JsonSchemaContract $schema): array
     {
         return array_merge(parent::defineSchema($schema), [
             'type' => JsonSchema::string()
@@ -816,6 +817,15 @@ class AssetsRouter extends BaseRouter
 
             if (! $container || ! $path || ! $destination) {
                 return $this->createErrorResponse('Container, path, and destination are required')->toArray();
+            }
+
+            $containerObj = AssetContainer::find($container);
+            if (! $containerObj) {
+                return $this->createErrorResponse("Asset container not found: {$container}")->toArray();
+            }
+
+            if (! $containerObj->allowMoving()) {
+                return $this->createErrorResponse("Container '{$container}' does not allow moving assets")->toArray();
             }
 
             $asset = Asset::find($container . '::' . $path);

--- a/src/Mcp/Tools/Routers/BlueprintsRouter.php
+++ b/src/Mcp/Tools/Routers/BlueprintsRouter.php
@@ -7,6 +7,7 @@ namespace Cboxdk\StatamicMcp\Mcp\Tools\Routers;
 use Cboxdk\StatamicMcp\Mcp\Tools\BaseRouter;
 use Cboxdk\StatamicMcp\Mcp\Tools\Concerns\ExecutesWithAudit;
 use Cboxdk\StatamicMcp\Mcp\Tools\Concerns\RouterHelpers;
+use Illuminate\Contracts\JsonSchema\JsonSchema as JsonSchemaContract;
 use Illuminate\JsonSchema\JsonSchema;
 use Illuminate\Support\Str;
 use Statamic\Facades\Blueprint;
@@ -178,7 +179,7 @@ class BlueprintsRouter extends BaseRouter
         ];
     }
 
-    protected function defineSchema(JsonSchema $schema): array
+    protected function defineSchema(JsonSchemaContract $schema): array
     {
         return array_merge(parent::defineSchema($schema), [
             'handle' => JsonSchema::string()

--- a/src/Mcp/Tools/Routers/ContentFacadeRouter.php
+++ b/src/Mcp/Tools/Routers/ContentFacadeRouter.php
@@ -8,6 +8,7 @@ use Cboxdk\StatamicMcp\Mcp\Tools\BaseRouter;
 use Cboxdk\StatamicMcp\Mcp\Tools\Concerns\ClearsCaches;
 use Cboxdk\StatamicMcp\Mcp\Tools\Concerns\HasCommonSchemas;
 use Cboxdk\StatamicMcp\Mcp\Tools\Concerns\RouterHelpers;
+use Illuminate\Contracts\JsonSchema\JsonSchema as JsonSchemaContract;
 use Illuminate\JsonSchema\JsonSchema;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
@@ -27,7 +28,7 @@ class ContentFacadeRouter extends BaseRouter
         return 'content-facade';
     }
 
-    protected function defineSchema(JsonSchema $schema): array
+    protected function defineSchema(JsonSchemaContract $schema): array
     {
         return array_merge(parent::defineSchema($schema), [
             'workflow' => JsonSchema::string()

--- a/src/Mcp/Tools/Routers/ContentRouter.php
+++ b/src/Mcp/Tools/Routers/ContentRouter.php
@@ -8,6 +8,7 @@ use Cboxdk\StatamicMcp\Mcp\Tools\BaseRouter;
 use Cboxdk\StatamicMcp\Mcp\Tools\Concerns\ClearsCaches;
 use Cboxdk\StatamicMcp\Mcp\Tools\Concerns\HasCommonSchemas;
 use Cboxdk\StatamicMcp\Mcp\Tools\Concerns\RouterHelpers;
+use Illuminate\Contracts\JsonSchema\JsonSchema as JsonSchemaContract;
 use Illuminate\JsonSchema\JsonSchema;
 use Illuminate\Support\Facades\Validator;
 use Statamic\Facades\Collection;
@@ -32,7 +33,7 @@ class ContentRouter extends BaseRouter
         return 'content';
     }
 
-    protected function defineSchema(JsonSchema $schema): array
+    protected function defineSchema(JsonSchemaContract $schema): array
     {
         return array_merge(parent::defineSchema($schema), [
             'type' => JsonSchema::string()

--- a/src/Mcp/Tools/Routers/EntriesRouter.php
+++ b/src/Mcp/Tools/Routers/EntriesRouter.php
@@ -8,6 +8,7 @@ use Cboxdk\StatamicMcp\Mcp\Tools\BaseRouter;
 use Cboxdk\StatamicMcp\Mcp\Tools\Concerns\ClearsCaches;
 use Cboxdk\StatamicMcp\Mcp\Tools\Concerns\HasCommonSchemas;
 use Cboxdk\StatamicMcp\Mcp\Tools\Concerns\RouterHelpers;
+use Illuminate\Contracts\JsonSchema\JsonSchema as JsonSchemaContract;
 use Illuminate\JsonSchema\JsonSchema;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
@@ -25,7 +26,7 @@ class EntriesRouter extends BaseRouter
         return 'entries';
     }
 
-    protected function defineSchema(JsonSchema $schema): array
+    protected function defineSchema(JsonSchemaContract $schema): array
     {
         return array_merge(parent::defineSchema($schema), [
             'collection' => JsonSchema::string()

--- a/src/Mcp/Tools/Routers/GlobalsRouter.php
+++ b/src/Mcp/Tools/Routers/GlobalsRouter.php
@@ -8,6 +8,7 @@ use Cboxdk\StatamicMcp\Mcp\Tools\BaseRouter;
 use Cboxdk\StatamicMcp\Mcp\Tools\Concerns\ClearsCaches;
 use Cboxdk\StatamicMcp\Mcp\Tools\Concerns\HasCommonSchemas;
 use Cboxdk\StatamicMcp\Mcp\Tools\Concerns\RouterHelpers;
+use Illuminate\Contracts\JsonSchema\JsonSchema as JsonSchemaContract;
 use Illuminate\JsonSchema\JsonSchema;
 use Statamic\Facades\GlobalSet;
 use Statamic\Facades\Site;
@@ -24,7 +25,7 @@ class GlobalsRouter extends BaseRouter
         return 'globals';
     }
 
-    protected function defineSchema(JsonSchema $schema): array
+    protected function defineSchema(JsonSchemaContract $schema): array
     {
         return array_merge(parent::defineSchema($schema), [
             'global_set' => JsonSchema::string()

--- a/src/Mcp/Tools/Routers/StructuresRouter.php
+++ b/src/Mcp/Tools/Routers/StructuresRouter.php
@@ -7,6 +7,7 @@ namespace Cboxdk\StatamicMcp\Mcp\Tools\Routers;
 use Cboxdk\StatamicMcp\Mcp\Tools\BaseRouter;
 use Cboxdk\StatamicMcp\Mcp\Tools\Concerns\ExecutesWithAudit;
 use Cboxdk\StatamicMcp\Mcp\Tools\Concerns\RouterHelpers;
+use Illuminate\Contracts\JsonSchema\JsonSchema as JsonSchemaContract;
 use Illuminate\JsonSchema\JsonSchema;
 use Statamic\Facades\Collection;
 use Statamic\Facades\GlobalSet;
@@ -125,7 +126,7 @@ class StructuresRouter extends BaseRouter
         ];
     }
 
-    protected function defineSchema(JsonSchema $schema): array
+    protected function defineSchema(JsonSchemaContract $schema): array
     {
         return array_merge(parent::defineSchema($schema), [
             'type' => JsonSchema::string()

--- a/src/Mcp/Tools/Routers/SystemRouter.php
+++ b/src/Mcp/Tools/Routers/SystemRouter.php
@@ -7,6 +7,7 @@ namespace Cboxdk\StatamicMcp\Mcp\Tools\Routers;
 use Cboxdk\StatamicMcp\Mcp\Tools\BaseRouter;
 use Cboxdk\StatamicMcp\Mcp\Tools\Concerns\ExecutesWithAudit;
 use Cboxdk\StatamicMcp\Mcp\Tools\Concerns\RouterHelpers;
+use Illuminate\Contracts\JsonSchema\JsonSchema as JsonSchemaContract;
 use Illuminate\JsonSchema\JsonSchema;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Cache;
@@ -126,7 +127,7 @@ class SystemRouter extends BaseRouter
         ];
     }
 
-    protected function defineSchema(JsonSchema $schema): array
+    protected function defineSchema(JsonSchemaContract $schema): array
     {
         return array_merge(parent::defineSchema($schema), [
             'type' => JsonSchema::string()

--- a/src/Mcp/Tools/Routers/TermsRouter.php
+++ b/src/Mcp/Tools/Routers/TermsRouter.php
@@ -8,6 +8,7 @@ use Cboxdk\StatamicMcp\Mcp\Tools\BaseRouter;
 use Cboxdk\StatamicMcp\Mcp\Tools\Concerns\ClearsCaches;
 use Cboxdk\StatamicMcp\Mcp\Tools\Concerns\HasCommonSchemas;
 use Cboxdk\StatamicMcp\Mcp\Tools\Concerns\RouterHelpers;
+use Illuminate\Contracts\JsonSchema\JsonSchema as JsonSchemaContract;
 use Illuminate\JsonSchema\JsonSchema;
 use Statamic\Facades\Site;
 use Statamic\Facades\Taxonomy;
@@ -25,7 +26,7 @@ class TermsRouter extends BaseRouter
         return 'terms';
     }
 
-    protected function defineSchema(JsonSchema $schema): array
+    protected function defineSchema(JsonSchemaContract $schema): array
     {
         return array_merge(parent::defineSchema($schema), [
             'taxonomy' => JsonSchema::string()

--- a/src/Mcp/Tools/Routers/UsersRouter.php
+++ b/src/Mcp/Tools/Routers/UsersRouter.php
@@ -7,6 +7,7 @@ namespace Cboxdk\StatamicMcp\Mcp\Tools\Routers;
 use Cboxdk\StatamicMcp\Mcp\Tools\BaseRouter;
 use Cboxdk\StatamicMcp\Mcp\Tools\Concerns\ExecutesWithAudit;
 use Cboxdk\StatamicMcp\Mcp\Tools\Concerns\RouterHelpers;
+use Illuminate\Contracts\JsonSchema\JsonSchema as JsonSchemaContract;
 use Illuminate\JsonSchema\JsonSchema;
 use Statamic\Facades\Role;
 use Statamic\Facades\User;
@@ -168,7 +169,7 @@ class UsersRouter extends BaseRouter
         ];
     }
 
-    protected function defineSchema(JsonSchema $schema): array
+    protected function defineSchema(JsonSchemaContract $schema): array
     {
         return array_merge(parent::defineSchema($schema), [
             'type' => JsonSchema::string()

--- a/src/Mcp/Tools/System/DiscoveryTool.php
+++ b/src/Mcp/Tools/System/DiscoveryTool.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Cboxdk\StatamicMcp\Mcp\Tools\System;
 
 use Cboxdk\StatamicMcp\Mcp\Tools\BaseStatamicTool;
+use Illuminate\Contracts\JsonSchema\JsonSchema as JsonSchemaContract;
 use Illuminate\JsonSchema\JsonSchema;
 use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
 use ReflectionClass;
@@ -40,7 +41,7 @@ class DiscoveryTool extends BaseStatamicTool
         return 'Discover and explore Statamic MCP tools with intent-based recommendations and context-aware guidance.';
     }
 
-    protected function defineSchema(JsonSchema $schema): array
+    protected function defineSchema(JsonSchemaContract $schema): array
     {
         return [
             'intent' => JsonSchema::string()

--- a/src/Mcp/Tools/System/SchemaTool.php
+++ b/src/Mcp/Tools/System/SchemaTool.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Cboxdk\StatamicMcp\Mcp\Tools\System;
 
 use Cboxdk\StatamicMcp\Mcp\Tools\BaseStatamicTool;
+use Illuminate\Contracts\JsonSchema\JsonSchema as JsonSchemaContract;
 use Illuminate\JsonSchema\JsonSchema;
 use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
 
@@ -30,7 +31,7 @@ class SchemaTool extends BaseStatamicTool
         return 'Inspect tool schemas, parameters, and usage documentation for all Statamic MCP tools.';
     }
 
-    protected function defineSchema(JsonSchema $schema): array
+    protected function defineSchema(JsonSchemaContract $schema): array
     {
         return [
             'tool_name' => JsonSchema::string()

--- a/tests/Feature/RefactoredToolsTest.php
+++ b/tests/Feature/RefactoredToolsTest.php
@@ -2,7 +2,7 @@
 
 use Cboxdk\StatamicMcp\Mcp\Tools\BaseStatamicTool;
 use Cboxdk\StatamicMcp\Mcp\Tools\Routers\SystemRouter;
-use Illuminate\JsonSchema\JsonSchema;
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
 
 describe('Refactored Tools', function () {
 
@@ -40,7 +40,7 @@ describe('Refactored Tools', function () {
         });
 
         it('defines schema correctly', function () {
-            $schema = new JsonSchema;
+            $schema = new JsonSchemaTypeFactory;
             $definedSchema = $this->router->schema($schema);
 
             expect($definedSchema)->toBeArray();

--- a/tests/Feature/Routers/AssetsRouterTest.php
+++ b/tests/Feature/Routers/AssetsRouterTest.php
@@ -435,8 +435,9 @@ class AssetsRouterTest extends TestCase
             'destination' => 'moved.txt',
         ]);
 
-        // Move should succeed in this case since the asset does get moved, just the router doesn't handle the allowMoving permission correctly
-        $this->assertTrue($result['success']);
+        // The container does not allow moving assets
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('does not allow moving assets', $result['errors'][0]);
     }
 
     public function test_rename_not_allowed(): void


### PR DESCRIPTION
## Summary

Fixes PHPStan Level 8 compliance issues and improves asset router permission handling.

## Changes

### PHPStan Type Compatibility
- Updated `defineSchema()` method parameter type from `JsonSchema` to `JsonSchemaContract` (interface) across all 14 tool files
- This resolves contravariance error with Laravel MCP v0.3.2 parent class `Tool`
- The parent class expects the interface type, not the concrete implementation

### Asset Router Permissions  
- Added container `allowMoving()` permission check to `AssetsRouter::moveAsset()`
- The router now properly validates container-level permissions before allowing asset moves
- Returns clear error message when container doesn't allow moving

### Test Fixes
- Updated `RefactoredToolsTest` to use `JsonSchemaTypeFactory` (which implements the interface) instead of `JsonSchema` (static factory that doesn't implement it)
- Updated `AssetsRouterTest::test_move_not_allowed` to verify the correct error message

## Files Modified

**Source code (14 files):**
- `src/Mcp/Tools/BaseStatamicTool.php`
- `src/Mcp/Tools/BaseRouter.php`
- `src/Mcp/Tools/Routers/AssetsRouter.php`
- `src/Mcp/Tools/Routers/BlueprintsRouter.php`
- `src/Mcp/Tools/Routers/ContentFacadeRouter.php`
- `src/Mcp/Tools/Routers/ContentRouter.php`
- `src/Mcp/Tools/Routers/EntriesRouter.php`
- `src/Mcp/Tools/Routers/GlobalsRouter.php`
- `src/Mcp/Tools/Routers/StructuresRouter.php`
- `src/Mcp/Tools/Routers/SystemRouter.php`
- `src/Mcp/Tools/Routers/TermsRouter.php`
- `src/Mcp/Tools/Routers/UsersRouter.php`
- `src/Mcp/Tools/System/DiscoveryTool.php`
- `src/Mcp/Tools/System/SchemaTool.php`

**Tests (2 files):**
- `tests/Feature/RefactoredToolsTest.php`
- `tests/Feature/Routers/AssetsRouterTest.php`

## Test Plan

- [x] PHPStan Level 8 analysis passes with zero errors
- [x] All 149 tests pass (1477 assertions)
- [x] Asset router correctly rejects moves when container has `allowMoving(false)`
- [x] Asset router allows moves when container has `allowMoving(true)`
- [x] Test file properly verifies error message content