### PR TITLE
chore(deps): widen laravel/mcp constraint to include v0.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "^8.3",
         "statamic/cms": "^5.65|^6.0",
-        "laravel/mcp": "^v0.4.2",
+        "laravel/mcp": "^0.4.1 || ^0.5",
         "symfony/yaml": "^7.3"
     },
     "require-dev": {


### PR DESCRIPTION
## Summary

- Expands the `laravel/mcp` version constraint from `^0.4.2` to `^0.4.1 || ^0.5`
- Ensures compatibility with the latest MCP protocol versions and future releases

## Problem

Users running `statamic-mcp` with older `laravel/mcp` versions (v0.3.x) encounter connection failures with Claude Code and other MCP clients:

```
MCP error -32602: Unsupported protocol version
```

This occurs because:
- **v0.3.x** only supports protocol versions: `2025-06-18`, `2025-03-26`, `2024-11-05`
- **Claude Code** now requests protocol version `2025-11-25`
- **v0.4.1** added support for `2025-11-25` ([laravel/mcp#changelog](https://github.com/laravel/mcp/releases/tag/v0.4.1))

## Solution

Widen the constraint to `^0.4.1 || ^0.5` which:
- Maintains compatibility with v0.4.x (current minimum in main branch)
- Allows automatic updates to v0.5.x (no breaking changes per changelog)
- Ensures users get protocol version `2025-11-25` support

## Why `^0.4.1` instead of `^0.4.2`?

The protocol version support was added in v0.4.1, so starting from that version ensures all users get the fix.

## Testing

Verified locally that `laravel/mcp` v0.4.2 and v0.5.1 both work correctly with Claude Code using protocol version `2025-11-25`.

## Related

This is a forward-compatibility improvement. The current `main` branch already has `^0.4.2` which works, but the widened constraint provides additional flexibility for future updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)