### PR TITLE
fix: date normalization and entry property extraction

### DIFF
--- a/src/Mcp/Tools/Concerns/NormalizesDateFields.php
+++ b/src/Mcp/Tools/Concerns/NormalizesDateFields.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cboxdk\StatamicMcp\Mcp\Tools\Concerns;
+
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+use Statamic\Fields\Blueprint;
+use Statamic\Fields\Field;
+
+trait NormalizesDateFields
+{
+    /**
+     * Normalize date field values in data to the format Statamic's FieldsValidator expects.
+     *
+     * Statamic's DateFieldtype validation requires: Y-m-d\TH:i:s.v\Z (ISO 8601 Zulu with milliseconds).
+     * LLMs may send dates as Y-m-d, Y-m-d H:i, ISO 8601, or {date, time} objects.
+     *
+     * @param  array<string, mixed>  $data
+     *
+     * @return array<string, mixed>
+     */
+    protected function normalizeDateFields(Blueprint $blueprint, array $data): array
+    {
+        /** @var Collection<string, Field> $fields */
+        $fields = $blueprint->fields()->all();
+
+        foreach ($fields as $handle => $field) {
+            if ($field->type() !== 'date' || ! array_key_exists($handle, $data)) {
+                continue;
+            }
+
+            $value = $data[$handle];
+            if ($value === null || $value === '') {
+                continue;
+            }
+
+            try {
+                $carbon = $this->parseDateValue($value);
+                $data[$handle] = $carbon->format('Y-m-d\TH:i:s.v\Z');
+            } catch (\Throwable) {
+                // Leave the value as-is; the FieldsValidator will report the error
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * Parse a date value from various formats into a Carbon instance.
+     *
+     * Accepts: ISO 8601, Y-m-d, Y-m-d H:i, Carbon instance, or {date, time} array.
+     */
+    protected function parseDateValue(mixed $value): Carbon
+    {
+        if ($value instanceof Carbon) {
+            return $value;
+        }
+
+        if (is_array($value)) {
+            $date = is_string($value['date'] ?? null) ? $value['date'] : '';
+            $time = is_string($value['time'] ?? null) ? $value['time'] : '00:00';
+
+            return Carbon::parse("{$date} {$time}");
+        }
+
+        if (is_string($value)) {
+            return Carbon::parse($value);
+        }
+
+        throw new \InvalidArgumentException('Date must be a string, Carbon instance, or {date, time} array.');
+    }
+}

--- a/src/Mcp/Tools/Routers/EntriesRouter.php
+++ b/src/Mcp/Tools/Routers/EntriesRouter.php
@@ -6,6 +6,7 @@ namespace Cboxdk\StatamicMcp\Mcp\Tools\Routers;
 
 use Cboxdk\StatamicMcp\Mcp\Tools\BaseRouter;
 use Cboxdk\StatamicMcp\Mcp\Tools\Concerns\ClearsCaches;
+use Cboxdk\StatamicMcp\Mcp\Tools\Concerns\NormalizesDateFields;
 use Illuminate\Contracts\JsonSchema\JsonSchema as JsonSchemaContract;
 use Illuminate\JsonSchema\JsonSchema;
 use Illuminate\Support\Facades\Validator;
@@ -23,6 +24,7 @@ use Statamic\Support\Str;
 class EntriesRouter extends BaseRouter
 {
     use ClearsCaches;
+    use NormalizesDateFields;
 
     protected function getDomain(): string
     {
@@ -324,6 +326,24 @@ class EntriesRouter extends BaseRouter
                 $entry->slug(Str::slug(is_string($titleValue) ? $titleValue : ''));
             }
 
+            // Extract published — it's a first-class entry property, not a data field
+            if (array_key_exists('published', $data)) {
+                $entry->published((bool) $data['published']);
+                unset($data['published']);
+            }
+
+            // For dated collections, parse the date and set it on the entry.
+            // Keep a normalized copy in data so the FieldsValidator sees the required field.
+            if (array_key_exists('date', $data) && $collection->dated()) {
+                try {
+                    $parsedDate = $this->parseDateValue($data['date']);
+                    $entry->date($parsedDate);
+                    $data['date'] = $parsedDate->format('Y-m-d\TH:i:s.v\Z');
+                } catch (\Throwable $e) {
+                    return $this->createErrorResponse("Invalid date value: {$e->getMessage()}")->toArray();
+                }
+            }
+
             // Get blueprint and validate field data
             $blueprint = $entry->blueprint();
 
@@ -332,6 +352,9 @@ class EntriesRouter extends BaseRouter
             }
 
             if (! empty($data)) {
+                // Normalize date field values to the format Statamic expects
+                $data = $this->normalizeDateFields($blueprint, $data);
+
                 // Add slug to data for validation if it's set
                 $dataWithSlug = $data;
                 if ($entry->slug()) {
@@ -339,21 +362,23 @@ class EntriesRouter extends BaseRouter
                 }
 
                 // Use Statamic's Fields Validator for blueprint-based validation
-                $fieldsValidator = (new FieldsValidator)
-                    ->fields($blueprint->fields()->addValues($dataWithSlug))
-                    ->withContext([
-                        'entry' => $entry,
-                        'collection' => $collection,
-                        'site' => $site,
-                    ]);
-
                 try {
+                    $fieldsValidator = (new FieldsValidator)
+                        ->fields($blueprint->fields()->addValues($dataWithSlug))
+                        ->withContext([
+                            'entry' => $entry,
+                            'collection' => $collection,
+                            'site' => $site,
+                        ]);
+
                     $validatedData = $fieldsValidator->validate();
-                    // Remove slug from validated data since it's handled separately
-                    unset($validatedData['slug']);
+                    // Remove entry-level properties from validated data
+                    unset($validatedData['slug'], $validatedData['date']);
                     $entry->data($validatedData);
                 } catch (ValidationException $e) {
                     return $this->formatValidationError($e);
+                } catch (\Throwable $e) {
+                    return $this->createErrorResponse('Failed to process entry data: ' . $e->getMessage())->toArray();
                 }
             } else {
                 $entry->data($data);
@@ -414,6 +439,24 @@ class EntriesRouter extends BaseRouter
                 }
             }
 
+            // Extract published — it's a first-class entry property
+            if (array_key_exists('published', $data)) {
+                $entry->published((bool) $data['published']);
+                unset($data['published']);
+            }
+
+            // For dated collections, parse the date and set it on the entry.
+            // Keep a normalized copy in data so the FieldsValidator sees the required field.
+            if (array_key_exists('date', $data) && $entry->collection()->dated()) {
+                try {
+                    $parsedDate = $this->parseDateValue($data['date']);
+                    $entry->date($parsedDate);
+                    $data['date'] = $parsedDate->format('Y-m-d\TH:i:s.v\Z');
+                } catch (\Throwable $e) {
+                    return $this->createErrorResponse("Invalid date value: {$e->getMessage()}")->toArray();
+                }
+            }
+
             // Validate data against blueprint before saving
             $blueprint = $entry->blueprint();
 
@@ -422,25 +465,33 @@ class EntriesRouter extends BaseRouter
             }
 
             if (! empty($data)) {
+                // Normalize date field values to the format Statamic expects
+                $data = $this->normalizeDateFields($blueprint, $data);
+
                 // Merge new data with existing for full blueprint validation
                 // Include slug since blueprint validates it as required
                 /** @var array<string, mixed> $mergedData */
                 $mergedData = array_merge($entry->data()->all(), $data);
                 $mergedData['slug'] = $entry->slug();
 
-                $fieldsValidator = (new FieldsValidator)
-                    ->fields($blueprint->fields()->addValues($mergedData))
-                    ->withContext([
-                        'entry' => $entry,
-                        'collection' => $entry->collection(),
-                        'site' => $site,
-                    ]);
-
                 try {
+                    $fieldsValidator = (new FieldsValidator)
+                        ->fields($blueprint->fields()->addValues($mergedData))
+                        ->withContext([
+                            'entry' => $entry,
+                            'collection' => $entry->collection(),
+                            'site' => $site,
+                        ]);
+
                     $fieldsValidator->validate();
                 } catch (ValidationException $e) {
                     return $this->formatValidationError($e);
+                } catch (\Throwable $e) {
+                    return $this->createErrorResponse('Failed to process entry data: ' . $e->getMessage())->toArray();
                 }
+
+                // Remove date from merge data — it's already set on the entry
+                unset($data['date']);
             }
 
             $entry->merge($data)->save();

--- a/src/Mcp/Tools/Routers/GlobalsRouter.php
+++ b/src/Mcp/Tools/Routers/GlobalsRouter.php
@@ -6,6 +6,7 @@ namespace Cboxdk\StatamicMcp\Mcp\Tools\Routers;
 
 use Cboxdk\StatamicMcp\Mcp\Tools\BaseRouter;
 use Cboxdk\StatamicMcp\Mcp\Tools\Concerns\ClearsCaches;
+use Cboxdk\StatamicMcp\Mcp\Tools\Concerns\NormalizesDateFields;
 use Illuminate\Contracts\JsonSchema\JsonSchema as JsonSchemaContract;
 use Illuminate\JsonSchema\JsonSchema;
 use Illuminate\Validation\ValidationException;
@@ -19,6 +20,7 @@ use Statamic\Fields\Validator;
 class GlobalsRouter extends BaseRouter
 {
     use ClearsCaches;
+    use NormalizesDateFields;
 
     protected function getDomain(): string
     {
@@ -274,21 +276,26 @@ class GlobalsRouter extends BaseRouter
             }
 
             if (! empty($data)) {
+                // Normalize date field values to the format Statamic expects
+                $data = $this->normalizeDateFields($blueprint, $data);
+
                 // Merge new data with existing for full blueprint validation
                 /** @var array<string, mixed> $mergedData */
                 $mergedData = array_merge($variables->data()->all(), $data);
 
-                $fieldsValidator = (new Validator)
-                    ->fields($blueprint->fields()->addValues($mergedData))
-                    ->withContext([
-                        'global_set' => $globalSet,
-                        'site' => $site,
-                    ]);
-
                 try {
+                    $fieldsValidator = (new Validator)
+                        ->fields($blueprint->fields()->addValues($mergedData))
+                        ->withContext([
+                            'global_set' => $globalSet,
+                            'site' => $site,
+                        ]);
+
                     $fieldsValidator->validate();
                 } catch (ValidationException $e) {
                     return $this->formatValidationError($e);
+                } catch (\Throwable $e) {
+                    return $this->createErrorResponse('Failed to process global data: ' . $e->getMessage())->toArray();
                 }
             }
 

--- a/src/Mcp/Tools/Routers/TermsRouter.php
+++ b/src/Mcp/Tools/Routers/TermsRouter.php
@@ -6,6 +6,7 @@ namespace Cboxdk\StatamicMcp\Mcp\Tools\Routers;
 
 use Cboxdk\StatamicMcp\Mcp\Tools\BaseRouter;
 use Cboxdk\StatamicMcp\Mcp\Tools\Concerns\ClearsCaches;
+use Cboxdk\StatamicMcp\Mcp\Tools\Concerns\NormalizesDateFields;
 use Illuminate\Contracts\JsonSchema\JsonSchema as JsonSchemaContract;
 use Illuminate\JsonSchema\JsonSchema;
 use Illuminate\Support\Facades\Validator;
@@ -23,6 +24,7 @@ use Statamic\Support\Str;
 class TermsRouter extends BaseRouter
 {
     use ClearsCaches;
+    use NormalizesDateFields;
 
     protected function getDomain(): string
     {
@@ -335,6 +337,9 @@ class TermsRouter extends BaseRouter
             }
 
             if (! empty($data)) {
+                // Normalize date field values to the format Statamic expects
+                $data = $this->normalizeDateFields($blueprint, $data);
+
                 // Add slug to data for validation if it's set
                 $dataWithSlug = $data;
                 if ($term->slug()) {
@@ -342,21 +347,23 @@ class TermsRouter extends BaseRouter
                 }
 
                 // Use Statamic's Fields Validator for blueprint-based validation
-                $fieldsValidator = (new FieldsValidator)
-                    ->fields($blueprint->fields()->addValues($dataWithSlug))
-                    ->withContext([
-                        'term' => $term,
-                        'taxonomy' => $taxonomy,
-                        'site' => $site,
-                    ]);
-
                 try {
+                    $fieldsValidator = (new FieldsValidator)
+                        ->fields($blueprint->fields()->addValues($dataWithSlug))
+                        ->withContext([
+                            'term' => $term,
+                            'taxonomy' => $taxonomy,
+                            'site' => $site,
+                        ]);
+
                     $validatedData = $fieldsValidator->validate();
                     // Remove slug from validated data since it's handled separately
                     unset($validatedData['slug']);
                     $term->data($validatedData);
                 } catch (ValidationException $e) {
                     return $this->formatValidationError($e);
+                } catch (\Throwable $e) {
+                    return $this->createErrorResponse('Failed to process term data: ' . $e->getMessage())->toArray();
                 }
             } else {
                 $term->data($data);
@@ -439,24 +446,29 @@ class TermsRouter extends BaseRouter
             $validatedData = is_array($data) ? $data : [];
 
             if (! empty($validatedData)) {
+                // Normalize date field values to the format Statamic expects
+                $validatedData = $this->normalizeDateFields($blueprint, $validatedData);
+
                 // Merge new data with existing for full blueprint validation
                 // Include slug since blueprint validates it as required
                 /** @var array<string, mixed> $mergedData */
                 $mergedData = array_merge($term->data()->all(), $validatedData);
                 $mergedData['slug'] = $term->slug();
 
-                $fieldsValidator = (new FieldsValidator)
-                    ->fields($blueprint->fields()->addValues($mergedData))
-                    ->withContext([
-                        'term' => $term,
-                        'taxonomy' => Taxonomy::find(is_string($taxonomy) ? $taxonomy : ''),
-                        'site' => $site,
-                    ]);
-
                 try {
+                    $fieldsValidator = (new FieldsValidator)
+                        ->fields($blueprint->fields()->addValues($mergedData))
+                        ->withContext([
+                            'term' => $term,
+                            'taxonomy' => Taxonomy::find(is_string($taxonomy) ? $taxonomy : ''),
+                            'site' => $site,
+                        ]);
+
                     $fieldsValidator->validate();
                 } catch (ValidationException $e) {
                     return $this->formatValidationError($e);
+                } catch (\Throwable $e) {
+                    return $this->createErrorResponse('Failed to process term data: ' . $e->getMessage())->toArray();
                 }
             }
 

--- a/tests/Integration/DateNormalizationTest.php
+++ b/tests/Integration/DateNormalizationTest.php
@@ -1,0 +1,295 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cboxdk\StatamicMcp\Tests\Integration;
+
+use Cboxdk\StatamicMcp\Mcp\Tools\Routers\EntriesRouter;
+use Cboxdk\StatamicMcp\Tests\Concerns\CreatesTestContent;
+use Cboxdk\StatamicMcp\Tests\TestCase;
+use Statamic\Facades\Blueprint as BlueprintFacade;
+use Statamic\Facades\Collection as CollectionFacade;
+use Statamic\Facades\Entry as EntryFacade;
+
+class DateNormalizationTest extends TestCase
+{
+    use CreatesTestContent;
+
+    private EntriesRouter $router;
+
+    private string $testId;
+
+    private string $datedCollection;
+
+    private string $collectionWithDateField;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->router = new EntriesRouter;
+        $this->testId = bin2hex(random_bytes(4));
+
+        // Dated collection (entry-level date property)
+        $this->datedCollection = "dated_{$this->testId}";
+        $collection = CollectionFacade::make($this->datedCollection)
+            ->title('Dated Collection')
+            ->dated(true);
+        $collection->save();
+
+        $blueprint = BlueprintFacade::makeFromFields([
+            'title' => ['type' => 'text', 'display' => 'Title'],
+        ]);
+        $blueprint->setHandle($this->datedCollection);
+        $blueprint->setNamespace("collections.{$this->datedCollection}");
+        $blueprint->save();
+
+        // Non-dated collection with a date blueprint field
+        $this->collectionWithDateField = "withdate_{$this->testId}";
+        CollectionFacade::make($this->collectionWithDateField)
+            ->title('With Date Field')
+            ->save();
+
+        $blueprint2 = BlueprintFacade::makeFromFields([
+            'title' => ['type' => 'text', 'display' => 'Title'],
+            'event_date' => ['type' => 'date', 'display' => 'Event Date', 'time_enabled' => false],
+        ]);
+        $blueprint2->setHandle($this->collectionWithDateField);
+        $blueprint2->setNamespace("collections.{$this->collectionWithDateField}");
+        $blueprint2->save();
+    }
+
+    // --- Entry-level date extraction for dated collections ---
+
+    public function test_create_entry_with_iso8601_date_on_dated_collection(): void
+    {
+        $result = $this->router->execute([
+            'action' => 'create',
+            'collection' => $this->datedCollection,
+            'data' => [
+                'title' => 'ISO Date Test',
+                'date' => '2026-04-10T09:00:00.000000Z',
+            ],
+        ]);
+
+        $this->assertTrue($result['success'], 'Failed: ' . json_encode($result['errors'] ?? []));
+        $this->assertTrue($result['data']['created']);
+
+        $entry = EntryFacade::find($result['data']['entry']['id']);
+        $this->assertNotNull($entry->date());
+        $this->assertEquals('2026-04-10', $entry->date()->format('Y-m-d'));
+    }
+
+    public function test_create_entry_with_simple_date_string_on_dated_collection(): void
+    {
+        $result = $this->router->execute([
+            'action' => 'create',
+            'collection' => $this->datedCollection,
+            'data' => [
+                'title' => 'Simple Date Test',
+                'date' => '2026-04-10',
+            ],
+        ]);
+
+        $this->assertTrue($result['success'], 'Failed: ' . json_encode($result['errors'] ?? []));
+
+        $entry = EntryFacade::find($result['data']['entry']['id']);
+        $this->assertEquals('2026-04-10', $entry->date()->format('Y-m-d'));
+    }
+
+    public function test_create_entry_with_datetime_string_on_dated_collection(): void
+    {
+        $result = $this->router->execute([
+            'action' => 'create',
+            'collection' => $this->datedCollection,
+            'data' => [
+                'title' => 'Datetime String Test',
+                'date' => '2026-04-10 14:30',
+            ],
+        ]);
+
+        $this->assertTrue($result['success'], 'Failed: ' . json_encode($result['errors'] ?? []));
+
+        $entry = EntryFacade::find($result['data']['entry']['id']);
+        $this->assertEquals('2026-04-10', $entry->date()->format('Y-m-d'));
+        $this->assertEquals('14:30', $entry->date()->format('H:i'));
+    }
+
+    public function test_create_entry_with_date_time_object_on_dated_collection(): void
+    {
+        $result = $this->router->execute([
+            'action' => 'create',
+            'collection' => $this->datedCollection,
+            'data' => [
+                'title' => 'Date Object Test',
+                'date' => ['date' => '2026-04-10', 'time' => '09:00'],
+            ],
+        ]);
+
+        $this->assertTrue($result['success'], 'Failed: ' . json_encode($result['errors'] ?? []));
+
+        $entry = EntryFacade::find($result['data']['entry']['id']);
+        $this->assertEquals('2026-04-10', $entry->date()->format('Y-m-d'));
+    }
+
+    // --- Published extraction ---
+
+    public function test_create_entry_with_published_false_in_data(): void
+    {
+        $result = $this->router->execute([
+            'action' => 'create',
+            'collection' => $this->datedCollection,
+            'data' => [
+                'title' => 'Draft Test',
+                'date' => '2026-04-10',
+                'published' => false,
+            ],
+        ]);
+
+        $this->assertTrue($result['success'], 'Failed: ' . json_encode($result['errors'] ?? []));
+        $this->assertFalse($result['data']['entry']['published']);
+    }
+
+    public function test_create_entry_with_published_true_in_data(): void
+    {
+        $result = $this->router->execute([
+            'action' => 'create',
+            'collection' => $this->datedCollection,
+            'data' => [
+                'title' => 'Published Test',
+                'date' => '2026-04-10',
+                'published' => true,
+            ],
+        ]);
+
+        $this->assertTrue($result['success'], 'Failed: ' . json_encode($result['errors'] ?? []));
+        $this->assertTrue($result['data']['entry']['published']);
+    }
+
+    // --- Blueprint date field normalization ---
+
+    public function test_create_entry_with_iso8601_date_in_blueprint_field(): void
+    {
+        $result = $this->router->execute([
+            'action' => 'create',
+            'collection' => $this->collectionWithDateField,
+            'data' => [
+                'title' => 'Event ISO Date',
+                'event_date' => '2026-06-15T00:00:00.000000Z',
+            ],
+        ]);
+
+        $this->assertTrue($result['success'], 'Failed: ' . json_encode($result['errors'] ?? []));
+    }
+
+    public function test_create_entry_with_simple_date_in_blueprint_field(): void
+    {
+        $result = $this->router->execute([
+            'action' => 'create',
+            'collection' => $this->collectionWithDateField,
+            'data' => [
+                'title' => 'Event Simple Date',
+                'event_date' => '2026-06-15',
+            ],
+        ]);
+
+        $this->assertTrue($result['success'], 'Failed: ' . json_encode($result['errors'] ?? []));
+    }
+
+    public function test_create_entry_with_date_time_object_in_blueprint_field(): void
+    {
+        $result = $this->router->execute([
+            'action' => 'create',
+            'collection' => $this->collectionWithDateField,
+            'data' => [
+                'title' => 'Event Object Date',
+                'event_date' => ['date' => '2026-06-15', 'time' => '10:00'],
+            ],
+        ]);
+
+        $this->assertTrue($result['success'], 'Failed: ' . json_encode($result['errors'] ?? []));
+    }
+
+    // --- Update with date ---
+
+    public function test_update_entry_date_on_dated_collection(): void
+    {
+        $entry = EntryFacade::make()
+            ->id("update-date-{$this->testId}")
+            ->collection($this->datedCollection)
+            ->slug("update-date-{$this->testId}")
+            ->data(['title' => 'Original'])
+            ->date(now());
+        $entry->save();
+
+        $result = $this->router->execute([
+            'action' => 'update',
+            'collection' => $this->datedCollection,
+            'id' => $entry->id(),
+            'data' => [
+                'title' => 'Updated',
+                'date' => '2026-12-25',
+            ],
+        ]);
+
+        $this->assertTrue($result['success'], 'Failed: ' . json_encode($result['errors'] ?? []));
+
+        $updated = EntryFacade::find($entry->id());
+        $this->assertEquals('2026-12-25', $updated->date()->format('Y-m-d'));
+    }
+
+    public function test_update_entry_published_state(): void
+    {
+        $entry = EntryFacade::make()
+            ->id("update-pub-{$this->testId}")
+            ->collection($this->datedCollection)
+            ->slug("update-pub-{$this->testId}")
+            ->data(['title' => 'Published Entry'])
+            ->published(true);
+        $entry->save();
+
+        $result = $this->router->execute([
+            'action' => 'update',
+            'collection' => $this->datedCollection,
+            'id' => $entry->id(),
+            'data' => ['published' => false],
+        ]);
+
+        $this->assertTrue($result['success'], 'Failed: ' . json_encode($result['errors'] ?? []));
+        $this->assertFalse($result['data']['entry']['published']);
+    }
+
+    // --- Error handling ---
+
+    public function test_invalid_date_value_returns_error(): void
+    {
+        $result = $this->router->execute([
+            'action' => 'create',
+            'collection' => $this->datedCollection,
+            'data' => [
+                'title' => 'Bad Date Test',
+                'date' => 'not-a-date-at-all',
+            ],
+        ]);
+
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('date', strtolower($result['errors'][0]));
+    }
+
+    public function test_invalid_blueprint_date_field_returns_validation_error(): void
+    {
+        $result = $this->router->execute([
+            'action' => 'create',
+            'collection' => $this->collectionWithDateField,
+            'data' => [
+                'title' => 'Invalid Date Field Test',
+                'event_date' => 'not-a-date',
+            ],
+        ]);
+
+        // parseDateValue will throw, normalizeDateFields catches it,
+        // then the FieldsValidator rejects the unparseable string
+        $this->assertFalse($result['success']);
+        $this->assertNotEmpty($result['errors']);
+    }
+}


### PR DESCRIPTION
## Summary
- **addValues() exception handling**: Wrapped `$blueprint->fields()->addValues()` inside try-catch in all routers (Entries, Terms, Globals) — fixes "Cannot access offset of type string on string" errors propagating uncaught
- **Entry-level property extraction**: `date` and `published` are now extracted from data and set as first-class entry properties (`$entry->date()` / `$entry->published()`) before validation, with normalized copies kept for the FieldsValidator
- **Date format normalization**: New `NormalizesDateFields` trait inspects blueprint fields and converts any date fieldtype values (`Y-m-d`, `Y-m-d H:i`, ISO 8601, `{date, time}` objects) to the Zulu format Statamic expects (`Y-m-d\TH:i:s.v\Z`)

## Test plan
- [x] 13 new integration tests covering all date formats, published extraction, update paths, and error handling
- [x] Full suite passes (789 tests, 4646 assertions)
- [x] PHPStan Level 8 — zero errors
- [x] Pint formatting clean