### PR TITLE
feat: confirmation tokens and granular resource policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,30 @@ The addon provides scoped API tokens for fine-grained MCP access control:
 - `AuthenticateForMcp` — Bearer token + Basic Auth fallback
 - `RequireMcpPermission` — Validates token scopes and expiry
 
+### Confirmation Tokens
+Destructive MCP operations require a two-step confirmation flow in production:
+- **ConfirmationTokenManager** (`src/Auth/ConfirmationTokenManager.php`) — Stateless HMAC-SHA256 tokens bound to tool + arguments
+- **RequiresConfirmation trait** (`src/Mcp/Tools/Concerns/RequiresConfirmation.php`) — Integrated into BaseRouter
+- **Operations requiring confirmation:** All `delete` actions + blueprint `create`/`update`/`delete`
+- **Environment-aware:** Auto-enabled in production, disabled in local/dev/testing (configurable via `STATAMIC_MCP_CONFIRMATION_ENABLED`)
+- **CLI bypass:** Confirmation is skipped in CLI context
+
+### Resource Policy
+Granular resource-level access control configured in `config/statamic/mcp.php`:
+- **ResourcePolicy** (`src/Auth/ResourcePolicy.php`) — Glob-based resource allowlists + field deny lists
+- **EnforcesResourcePolicy trait** (`src/Mcp/Tools/Concerns/EnforcesResourcePolicy.php`) — Integrated into BaseRouter
+- **Per-domain config:** `resources.read`/`resources.write` (glob patterns) + `denied_fields` (field names to strip)
+- **Applies everywhere:** Resource policy is enforced in both CLI and web contexts (site-wide admin policy)
+- **Field filtering:** Denied fields silently stripped from both input and output
+
+### Authorization Evaluation Order (Web Context)
+1. Tool enabled? → `config: tools.{domain}.enabled`
+2. Token scope? → `TokenScope: {domain}:{read|write}`
+3. Resource allowed? → `ResourcePolicy::canAccess(domain, handle, mode)`
+4. Statamic permissions? → `User::hasPermission()`
+5. Confirmation required? → `ConfirmationTokenManager` (deletes + blueprint writes)
+6. Field filtering → `ResourcePolicy::filterFields()` on input + output
+
 ### OAuth 2.1 Authorization Server
 The addon includes a full OAuth 2.1 authorization server with PKCE for browser-based MCP clients:
 

--- a/config/statamic/mcp.php
+++ b/config/statamic/mcp.php
@@ -111,6 +111,24 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Confirmation Tokens
+    |--------------------------------------------------------------------------
+    |
+    | Require a two-step confirmation flow for destructive operations.
+    | Uses stateless HMAC-SHA256 tokens bound to the exact operation.
+    |
+    | When enabled is null (default), confirmation is auto-detected:
+    | enabled in production, disabled in local/development/testing/staging.
+    | Set to true/false to override.
+    |
+    */
+    'confirmation' => [
+        'enabled' => env('STATAMIC_MCP_CONFIRMATION_ENABLED', null),
+        'ttl' => (int) env('STATAMIC_MCP_CONFIRMATION_TTL', 300),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Rate Limiting
     |--------------------------------------------------------------------------
     |
@@ -162,24 +180,59 @@ return [
     'tools' => [
         'blueprints' => [
             'enabled' => env('STATAMIC_MCP_TOOL_BLUEPRINTS_ENABLED', true),
+            'resources' => [
+                'read' => ['*'],
+                'write' => ['*'],
+            ],
+            'denied_fields' => [],
         ],
         'entries' => [
             'enabled' => env('STATAMIC_MCP_TOOL_ENTRIES_ENABLED', true),
+            'resources' => [
+                'read' => ['*'],
+                'write' => ['*'],
+            ],
+            'denied_fields' => [],
         ],
         'terms' => [
             'enabled' => env('STATAMIC_MCP_TOOL_TERMS_ENABLED', true),
+            'resources' => [
+                'read' => ['*'],
+                'write' => ['*'],
+            ],
+            'denied_fields' => [],
         ],
         'globals' => [
             'enabled' => env('STATAMIC_MCP_TOOL_GLOBALS_ENABLED', true),
+            'resources' => [
+                'read' => ['*'],
+                'write' => ['*'],
+            ],
+            'denied_fields' => [],
         ],
         'structures' => [
             'enabled' => env('STATAMIC_MCP_TOOL_STRUCTURES_ENABLED', true),
+            'resources' => [
+                'read' => ['*'],
+                'write' => ['*'],
+            ],
+            'denied_fields' => [],
         ],
         'assets' => [
             'enabled' => env('STATAMIC_MCP_TOOL_ASSETS_ENABLED', true),
+            'resources' => [
+                'read' => ['*'],
+                'write' => ['*'],
+            ],
+            'denied_fields' => [],
         ],
         'users' => [
             'enabled' => env('STATAMIC_MCP_TOOL_USERS_ENABLED', true),
+            'resources' => [
+                'read' => ['*'],
+                'write' => ['*'],
+            ],
+            'denied_fields' => [],
         ],
         'system' => [
             'enabled' => env('STATAMIC_MCP_TOOL_SYSTEM_ENABLED', true),

--- a/src/Auth/ConfirmationTokenManager.php
+++ b/src/Auth/ConfirmationTokenManager.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cboxdk\StatamicMcp\Auth;
+
+class ConfirmationTokenManager
+{
+    /**
+     * Generate an HMAC-signed confirmation token for a specific tool + arguments.
+     *
+     * @param  array<string, mixed>  $arguments
+     */
+    public function generate(string $tool, array $arguments): string
+    {
+        $timestamp = time();
+        $payload = $this->buildPayload($tool, $arguments, $timestamp);
+
+        $signature = hash_hmac('sha256', $payload, $this->getKey());
+
+        return base64_encode($timestamp . '.' . $signature);
+    }
+
+    /**
+     * Validate a confirmation token against a tool + arguments.
+     *
+     * @param  array<string, mixed>  $arguments
+     */
+    public function validate(string $token, string $tool, array $arguments): bool
+    {
+        if ($token === '') {
+            return false;
+        }
+
+        $decoded = base64_decode($token, true);
+        if ($decoded === false) {
+            return false;
+        }
+
+        $dotPos = strpos($decoded, '.');
+        if ($dotPos === false) {
+            return false;
+        }
+
+        $timestampStr = substr($decoded, 0, $dotPos);
+        $signature = substr($decoded, $dotPos + 1);
+
+        if (! is_numeric($timestampStr) || $signature === '') {
+            return false;
+        }
+
+        $timestamp = (int) $timestampStr;
+
+        // Check expiry
+        /** @var int $ttl */
+        $ttl = config('statamic.mcp.confirmation.ttl', 300);
+        if ((time() - $timestamp) > $ttl) {
+            return false;
+        }
+
+        // Rebuild payload and compare signatures
+        $expectedPayload = $this->buildPayload($tool, $arguments, $timestamp);
+        $expectedSignature = hash_hmac('sha256', $expectedPayload, $this->getKey());
+
+        return hash_equals($expectedSignature, $signature);
+    }
+
+    /**
+     * Check if confirmation tokens are enabled for the current environment.
+     */
+    public function isEnabled(): bool
+    {
+        /** @var bool|null $enabled */
+        $enabled = config('statamic.mcp.confirmation.enabled');
+
+        if ($enabled !== null) {
+            return (bool) $enabled;
+        }
+
+        // Auto-detect: enabled in production only
+        return app()->environment('production');
+    }
+
+    /**
+     * Build the canonical payload string for HMAC signing.
+     *
+     * @param  array<string, mixed>  $arguments
+     */
+    private function buildPayload(string $tool, array $arguments, int $timestamp): string
+    {
+        // Strip the confirmation_token from arguments before canonicalizing
+        unset($arguments['confirmation_token']);
+
+        // Sort keys for canonical ordering
+        ksort($arguments);
+
+        $canonical = json_encode($arguments, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        return $tool . '|' . $canonical . '|' . $timestamp;
+    }
+
+    /**
+     * Get the application key used for HMAC signing.
+     */
+    private function getKey(): string
+    {
+        /** @var string $key */
+        $key = config('app.key', '');
+
+        // Strip the base64: prefix if present
+        if (str_starts_with($key, 'base64:')) {
+            $decoded = base64_decode(substr($key, 7), true);
+
+            return $decoded !== false ? $decoded : $key;
+        }
+
+        return $key;
+    }
+}

--- a/src/Auth/ResourcePolicy.php
+++ b/src/Auth/ResourcePolicy.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cboxdk\StatamicMcp\Auth;
+
+class ResourcePolicy
+{
+    /**
+     * Check if a specific resource is accessible for the given mode.
+     */
+    public function canAccess(string $domain, string $resource, string $mode): bool
+    {
+        /** @var array<int, string>|null $patterns */
+        $patterns = config("statamic.mcp.tools.{$domain}.resources.{$mode}");
+
+        // Unconfigured domain/mode defaults to allow all
+        if ($patterns === null) {
+            return true;
+        }
+
+        foreach ($patterns as $pattern) {
+            if (fnmatch($pattern, $resource)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Get the list of denied fields for a domain.
+     *
+     * @return array<int, string>
+     */
+    public function getDeniedFields(string $domain): array
+    {
+        /** @var array<int, string> $fields */
+        $fields = config("statamic.mcp.tools.{$domain}.denied_fields", []);
+
+        return $fields;
+    }
+
+    /**
+     * Recursively strip denied fields from data.
+     *
+     * @param  array<string, mixed>  $data
+     *
+     * @return array<string, mixed>
+     */
+    public function filterFields(string $domain, array $data): array
+    {
+        $deniedFields = $this->getDeniedFields($domain);
+
+        if ($deniedFields === []) {
+            return $data;
+        }
+
+        return $this->recursiveFilter($data, $deniedFields);
+    }
+
+    /**
+     * Recursively remove denied keys from an array structure.
+     *
+     * @param  array<mixed>  $data
+     * @param  array<int, string>  $deniedFields
+     *
+     * @return array<mixed>
+     */
+    private function recursiveFilter(array $data, array $deniedFields): array
+    {
+        $result = [];
+
+        foreach ($data as $key => $value) {
+            // Strip denied string keys
+            if (is_string($key) && in_array($key, $deniedFields, true)) {
+                continue;
+            }
+
+            if (is_array($value)) {
+                $result[$key] = $this->recursiveFilter($value, $deniedFields);
+            } else {
+                $result[$key] = $value;
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/Mcp/Tools/BaseRouter.php
+++ b/src/Mcp/Tools/BaseRouter.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Cboxdk\StatamicMcp\Mcp\Tools;
 
 use Cboxdk\StatamicMcp\Mcp\Tools\Concerns\BuildsPaginatedResponse;
+use Cboxdk\StatamicMcp\Mcp\Tools\Concerns\EnforcesResourcePolicy;
+use Cboxdk\StatamicMcp\Mcp\Tools\Concerns\RequiresConfirmation;
 use Cboxdk\StatamicMcp\Mcp\Tools\Concerns\RouterHelpers;
 use Illuminate\Contracts\JsonSchema\JsonSchema as JsonSchemaContract;
 use Illuminate\JsonSchema\JsonSchema;
@@ -15,6 +17,8 @@ use Illuminate\JsonSchema\JsonSchema;
 abstract class BaseRouter extends BaseStatamicTool
 {
     use BuildsPaginatedResponse;
+    use EnforcesResourcePolicy;
+    use RequiresConfirmation;
     use RouterHelpers;
 
     /**
@@ -90,14 +94,34 @@ abstract class BaseRouter extends BaseStatamicTool
             )->toArray();
         }
 
+        $action = is_string($arguments['action'] ?? null) ? $arguments['action'] : '';
+
         if ($this->isWebContext()) {
-            $action = is_string($arguments['action'] ?? null) ? $arguments['action'] : '';
             $permissionError = $this->checkWebPermissions($action, $arguments);
             if ($permissionError) {
                 return $permissionError;
             }
         }
 
-        return $this->executeAction($arguments);
+        // Resource policy check (applies in ALL contexts — site-wide admin policy)
+        $resourceError = $this->checkResourceAccess($action, $arguments);
+        if ($resourceError) {
+            return $resourceError;
+        }
+
+        // Confirmation check (skipped in CLI and when disabled)
+        $confirmationResponse = $this->handleConfirmation($action, $arguments);
+        if ($confirmationResponse) {
+            return $confirmationResponse;
+        }
+
+        // Filter denied fields from input
+        $arguments = $this->filterInputFields($arguments);
+
+        // Execute the action
+        $result = $this->executeAction($arguments);
+
+        // Filter denied fields from output
+        return $this->filterOutputFields($result);
     }
 }

--- a/src/Mcp/Tools/Concerns/EnforcesResourcePolicy.php
+++ b/src/Mcp/Tools/Concerns/EnforcesResourcePolicy.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cboxdk\StatamicMcp\Mcp\Tools\Concerns;
+
+use Cboxdk\StatamicMcp\Auth\ResourcePolicy;
+
+/**
+ * Enforces resource-level access control and field filtering on router actions.
+ *
+ * Resource policy is a site-wide admin config — it applies in ALL contexts
+ * (CLI and web), unlike token scopes which are web-only.
+ */
+trait EnforcesResourcePolicy
+{
+    /**
+     * Check if the current action is allowed on the target resource.
+     *
+     * Returns an error response array if denied, or null if allowed.
+     *
+     * @param  array<string, mixed>  $arguments
+     *
+     * @return array<string, mixed>|null
+     */
+    protected function checkResourceAccess(string $action, array $arguments): ?array
+    {
+        $handle = $this->resolveResourceHandle($arguments);
+
+        // No handle to check (e.g., list without collection filter) — allow
+        if ($handle === null) {
+            return null;
+        }
+
+        $mode = $this->isWriteAction($action) ? 'write' : 'read';
+
+        /** @var ResourcePolicy $policy */
+        $policy = app(ResourcePolicy::class);
+
+        if (! $policy->canAccess($this->getDomain(), $handle, $mode)) {
+            return $this->createErrorResponse(
+                ucfirst($mode) . " access to '{$handle}' is not permitted by resource policy"
+            )->toArray();
+        }
+
+        return null;
+    }
+
+    /**
+     * Filter denied fields from input arguments.
+     *
+     * @param  array<string, mixed>  $arguments
+     *
+     * @return array<string, mixed>
+     */
+    protected function filterInputFields(array $arguments): array
+    {
+        /** @var ResourcePolicy $policy */
+        $policy = app(ResourcePolicy::class);
+
+        $domain = $this->getDomain();
+
+        if ($policy->getDeniedFields($domain) === []) {
+            return $arguments;
+        }
+
+        // Filter 'data' key if present (entries, terms, globals)
+        if (isset($arguments['data']) && is_array($arguments['data'])) {
+            $arguments['data'] = $policy->filterFields($domain, $arguments['data']);
+        }
+
+        // Filter 'fields' key if present (blueprints)
+        if (isset($arguments['fields']) && is_array($arguments['fields'])) {
+            $arguments['fields'] = $policy->filterFields($domain, $arguments['fields']);
+        }
+
+        return $arguments;
+    }
+
+    /**
+     * Filter denied fields from output data.
+     *
+     * @param  array<string, mixed>  $result
+     *
+     * @return array<string, mixed>
+     */
+    protected function filterOutputFields(array $result): array
+    {
+        /** @var ResourcePolicy $policy */
+        $policy = app(ResourcePolicy::class);
+
+        $domain = $this->getDomain();
+
+        if ($policy->getDeniedFields($domain) === []) {
+            return $result;
+        }
+
+        // Filter the 'data' key in the result
+        if (isset($result['data']) && is_array($result['data'])) {
+            $result['data'] = $policy->filterFields($domain, $result['data']);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Extract the resource handle from arguments for policy evaluation.
+     *
+     * Returns null for actions that don't target a specific resource
+     * (e.g., list without a filter). When null, resource-level check is skipped.
+     *
+     * @param  array<string, mixed>  $arguments
+     */
+    protected function resolveResourceHandle(array $arguments): ?string
+    {
+        // Try common argument names in priority order
+        foreach (['collection', 'taxonomy', 'container', 'handle', 'navigation'] as $key) {
+            if (isset($arguments[$key]) && is_string($arguments[$key]) && $arguments[$key] !== '') {
+                return $arguments[$key];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Check if an action is a write action.
+     */
+    private function isWriteAction(string $action): bool
+    {
+        return in_array($action, [
+            'create', 'update', 'delete', 'publish', 'unpublish',
+            'activate', 'deactivate', 'assign_role', 'remove_role',
+            'move', 'copy', 'upload', 'configure',
+            'cache_clear', 'cache_warm', 'config_set',
+        ], true);
+    }
+}

--- a/src/Mcp/Tools/Concerns/RequiresConfirmation.php
+++ b/src/Mcp/Tools/Concerns/RequiresConfirmation.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cboxdk\StatamicMcp\Mcp\Tools\Concerns;
+
+use Cboxdk\StatamicMcp\Auth\ConfirmationTokenManager;
+
+/**
+ * Provides confirmation token flow for destructive router actions.
+ *
+ * Routers using this trait call handleConfirmation() early in action methods.
+ * Returns a confirmation request array if no valid token is provided, or null
+ * if confirmation was successful (proceed with execution).
+ */
+trait RequiresConfirmation
+{
+    /**
+     * Check if the given action requires confirmation for this router.
+     */
+    protected function requiresConfirmation(string $action): bool
+    {
+        // All routers: delete requires confirmation
+        if ($action === 'delete') {
+            return true;
+        }
+
+        // BlueprintsRouter: create and update also require confirmation
+        if ($this->getDomain() === 'blueprints' && in_array($action, ['create', 'update'], true)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Handle the confirmation flow for a destructive action.
+     *
+     * Returns a confirmation request array if the agent needs to confirm,
+     * or null if confirmation is valid or not required (proceed with action).
+     *
+     * @param  array<string, mixed>  $arguments
+     *
+     * @return array<string, mixed>|null
+     */
+    protected function handleConfirmation(string $action, array $arguments): ?array
+    {
+        // Skip if confirmation is not required for this action
+        if (! $this->requiresConfirmation($action)) {
+            return null;
+        }
+
+        /** @var ConfirmationTokenManager $manager */
+        $manager = app(ConfirmationTokenManager::class);
+
+        // Skip if confirmation is disabled (env-aware)
+        if (! $manager->isEnabled()) {
+            return null;
+        }
+
+        // Skip in CLI context
+        if ($this->isCliContext()) {
+            return null;
+        }
+
+        // Check if a valid confirmation token was provided
+        $token = $arguments['confirmation_token'] ?? null;
+        if (is_string($token) && $token !== '') {
+            $toolName = $this->name();
+            if ($manager->validate($token, $toolName, $arguments)) {
+                return null; // Token valid, proceed
+            }
+
+            // Invalid or expired token
+            return $this->createErrorResponse(
+                'Invalid or expired confirmation token. Request a new one by calling without confirmation_token.',
+            )->toArray();
+        }
+
+        // No token provided — generate one and return confirmation request
+        $toolName = $this->name();
+        $confirmationToken = $manager->generate($toolName, $arguments);
+
+        /** @var int $ttl */
+        $ttl = config('statamic.mcp.confirmation.ttl', 300);
+
+        return $this->createErrorResponse(
+            'This operation requires confirmation. Resubmit with the provided confirmation_token to proceed.',
+            [
+                'requires_confirmation' => true,
+                'confirmation_token' => $confirmationToken,
+                'description' => $this->buildConfirmationDescription($action, $arguments),
+                'expires_in' => $ttl,
+            ],
+        )->toArray();
+    }
+
+    /**
+     * Build a human-readable description of what the confirmed action will do.
+     *
+     * @param  array<string, mixed>  $arguments
+     */
+    protected function buildConfirmationDescription(string $action, array $arguments): string
+    {
+        $domain = $this->getDomain();
+        $handle = $arguments['handle'] ?? $arguments['slug'] ?? $arguments['id'] ?? 'unknown';
+        $handle = is_string($handle) ? $handle : 'unknown';
+
+        $resourceContext = '';
+        if (isset($arguments['collection']) && is_string($arguments['collection'])) {
+            $resourceContext = " from collection '{$arguments['collection']}'";
+        } elseif (isset($arguments['taxonomy']) && is_string($arguments['taxonomy'])) {
+            $resourceContext = " from taxonomy '{$arguments['taxonomy']}'";
+        } elseif (isset($arguments['namespace']) && is_string($arguments['namespace'])) {
+            $resourceContext = " in namespace '{$arguments['namespace']}'";
+        } elseif (isset($arguments['container']) && is_string($arguments['container'])) {
+            $resourceContext = " from container '{$arguments['container']}'";
+        }
+
+        return match ($action) {
+            'delete' => "Delete {$domain} '{$handle}'{$resourceContext}. This action cannot be undone.",
+            'create' => "Create {$domain} '{$handle}'{$resourceContext}.",
+            'update' => "Update {$domain} '{$handle}'{$resourceContext}.",
+            default => ucfirst($action) . " {$domain} '{$handle}'{$resourceContext}.",
+        };
+    }
+}

--- a/src/Mcp/Tools/Routers/BlueprintsRouter.php
+++ b/src/Mcp/Tools/Routers/BlueprintsRouter.php
@@ -691,11 +691,6 @@ class BlueprintsRouter extends BaseRouter
         try {
             $handle = is_string($arguments['handle']) ? $arguments['handle'] : '';
             $namespace = isset($arguments['namespace']) && is_string($arguments['namespace']) ? $arguments['namespace'] : null;
-            $confirm = $this->getBooleanArgument($arguments, 'confirm', false);
-
-            if (! $confirm) {
-                return $this->createErrorResponse('Deletion requires explicit confirmation (set confirm to true)')->toArray();
-            }
 
             // Find the blueprint
             $collectionHandle = isset($arguments['collection_handle']) && is_string($arguments['collection_handle']) ? $arguments['collection_handle'] : null;

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Cboxdk\StatamicMcp;
 
 use Cboxdk\StatamicMcp\Auth\AuthServiceProvider;
+use Cboxdk\StatamicMcp\Auth\ConfirmationTokenManager;
+use Cboxdk\StatamicMcp\Auth\ResourcePolicy;
 use Cboxdk\StatamicMcp\Console\InstallCommand;
 use Cboxdk\StatamicMcp\Console\MigrateStoreCommand;
 use Cboxdk\StatamicMcp\Console\PruneAuditCommand;
@@ -155,6 +157,12 @@ class ServiceProvider extends AddonServiceProvider
 
         // Register CIMD resolver
         $this->app->singleton(CimdResolver::class);
+
+        // Register confirmation token manager
+        $this->app->singleton(ConfirmationTokenManager::class);
+
+        // Register resource policy
+        $this->app->singleton(ResourcePolicy::class);
 
         // Register auth services
         $this->app->register(AuthServiceProvider::class);

--- a/tests/Feature/Routers/BlueprintsRouterTest.php
+++ b/tests/Feature/Routers/BlueprintsRouterTest.php
@@ -450,16 +450,15 @@ class BlueprintsRouterTest extends TestCase
         $this->assertStringContainsString('Taxonomy not found: nonexistent_taxonomy', $result['errors'][0]);
     }
 
-    public function test_delete_blueprint_requires_explicit_confirmation(): void
+    public function test_delete_nonexistent_blueprint_returns_not_found(): void
     {
         $result = $this->router->execute([
             'action' => 'delete',
             'handle' => 'some_blueprint',
-            'confirm' => false,
         ]);
 
         $this->assertFalse($result['success']);
-        $this->assertStringContainsString('Deletion requires explicit confirmation', $result['errors'][0]);
+        $this->assertStringContainsString('Blueprint not found', $result['errors'][0]);
     }
 
     public function test_generate_blueprint_requires_fields(): void

--- a/tests/Unit/Auth/ConfirmationTokenManagerTest.php
+++ b/tests/Unit/Auth/ConfirmationTokenManagerTest.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+use Cboxdk\StatamicMcp\Auth\ConfirmationTokenManager;
+use Illuminate\Support\Facades\Config;
+
+beforeEach(function (): void {
+    Config::set('app.key', 'base64:' . base64_encode(random_bytes(32)));
+    Config::set('statamic.mcp.confirmation.ttl', 300);
+});
+
+// ---------------------------------------------------------------------------
+// Generation
+// ---------------------------------------------------------------------------
+
+it('generates a non-empty base64url token', function (): void {
+    $manager = new ConfirmationTokenManager;
+
+    $token = $manager->generate('statamic-entries', ['action' => 'delete', 'handle' => 'about']);
+
+    expect($token)->toBeString()->not->toBeEmpty();
+});
+
+it('generates different tokens for different arguments', function (): void {
+    $manager = new ConfirmationTokenManager;
+
+    $token1 = $manager->generate('statamic-entries', ['action' => 'delete', 'handle' => 'about']);
+    $token2 = $manager->generate('statamic-entries', ['action' => 'delete', 'handle' => 'contact']);
+
+    expect($token1)->not->toBe($token2);
+});
+
+it('generates different tokens for different tools', function (): void {
+    $manager = new ConfirmationTokenManager;
+
+    $token1 = $manager->generate('statamic-entries', ['action' => 'delete', 'handle' => 'about']);
+    $token2 = $manager->generate('statamic-blueprints', ['action' => 'delete', 'handle' => 'about']);
+
+    expect($token1)->not->toBe($token2);
+});
+
+// ---------------------------------------------------------------------------
+// Validation — success
+// ---------------------------------------------------------------------------
+
+it('validates a token that was just generated', function (): void {
+    $manager = new ConfirmationTokenManager;
+
+    $args = ['action' => 'delete', 'handle' => 'about'];
+    $token = $manager->generate('statamic-entries', $args);
+
+    expect($manager->validate($token, 'statamic-entries', $args))->toBeTrue();
+});
+
+it('strips confirmation_token key before validating', function (): void {
+    $manager = new ConfirmationTokenManager;
+
+    $args = ['action' => 'delete', 'handle' => 'about'];
+    $token = $manager->generate('statamic-entries', $args);
+
+    // Agent sends back arguments including the token itself
+    $argsWithToken = array_merge($args, ['confirmation_token' => $token]);
+
+    expect($manager->validate($token, 'statamic-entries', $argsWithToken))->toBeTrue();
+});
+
+it('validates with arguments in different key order', function (): void {
+    $manager = new ConfirmationTokenManager;
+
+    $args1 = ['action' => 'delete', 'handle' => 'about'];
+    $token = $manager->generate('statamic-entries', $args1);
+
+    // Same arguments, different key order
+    $args2 = ['handle' => 'about', 'action' => 'delete'];
+
+    expect($manager->validate($token, 'statamic-entries', $args2))->toBeTrue();
+});
+
+// ---------------------------------------------------------------------------
+// Validation — failure
+// ---------------------------------------------------------------------------
+
+it('rejects a tampered token', function (): void {
+    $manager = new ConfirmationTokenManager;
+
+    $token = $manager->generate('statamic-entries', ['action' => 'delete', 'handle' => 'about']);
+    $tampered = $token . 'x';
+
+    expect($manager->validate($tampered, 'statamic-entries', ['action' => 'delete', 'handle' => 'about']))->toBeFalse();
+});
+
+it('rejects a token with modified arguments', function (): void {
+    $manager = new ConfirmationTokenManager;
+
+    $token = $manager->generate('statamic-entries', ['action' => 'delete', 'handle' => 'about']);
+
+    expect($manager->validate($token, 'statamic-entries', ['action' => 'delete', 'handle' => 'contact']))->toBeFalse();
+});
+
+it('rejects a token with wrong tool name', function (): void {
+    $manager = new ConfirmationTokenManager;
+
+    $token = $manager->generate('statamic-entries', ['action' => 'delete', 'handle' => 'about']);
+
+    expect($manager->validate($token, 'statamic-blueprints', ['action' => 'delete', 'handle' => 'about']))->toBeFalse();
+});
+
+it('rejects an expired token', function (): void {
+    Config::set('statamic.mcp.confirmation.ttl', 1); // 1 second TTL
+
+    $manager = new ConfirmationTokenManager;
+
+    $args = ['action' => 'delete', 'handle' => 'about'];
+    $token = $manager->generate('statamic-entries', $args);
+
+    // Wait for expiry
+    sleep(2);
+
+    expect($manager->validate($token, 'statamic-entries', $args))->toBeFalse();
+});
+
+it('rejects an empty string token', function (): void {
+    $manager = new ConfirmationTokenManager;
+
+    expect($manager->validate('', 'statamic-entries', ['action' => 'delete']))->toBeFalse();
+});
+
+it('rejects a malformed token without separator', function (): void {
+    $manager = new ConfirmationTokenManager;
+
+    expect($manager->validate('notavalidtoken', 'statamic-entries', ['action' => 'delete']))->toBeFalse();
+});
+
+// ---------------------------------------------------------------------------
+// Environment-aware enabled check
+// ---------------------------------------------------------------------------
+
+it('reports enabled in production when config is null', function (): void {
+    Config::set('statamic.mcp.confirmation.enabled', null);
+    app()['env'] = 'production';
+
+    $manager = new ConfirmationTokenManager;
+
+    expect($manager->isEnabled())->toBeTrue();
+});
+
+it('reports disabled in local when config is null', function (): void {
+    Config::set('statamic.mcp.confirmation.enabled', null);
+    app()['env'] = 'local';
+
+    $manager = new ConfirmationTokenManager;
+
+    expect($manager->isEnabled())->toBeFalse();
+});
+
+it('reports disabled in testing when config is null', function (): void {
+    Config::set('statamic.mcp.confirmation.enabled', null);
+    app()['env'] = 'testing';
+
+    $manager = new ConfirmationTokenManager;
+
+    expect($manager->isEnabled())->toBeFalse();
+});
+
+it('respects explicit true override regardless of environment', function (): void {
+    Config::set('statamic.mcp.confirmation.enabled', true);
+    app()['env'] = 'local';
+
+    $manager = new ConfirmationTokenManager;
+
+    expect($manager->isEnabled())->toBeTrue();
+});
+
+it('respects explicit false override regardless of environment', function (): void {
+    Config::set('statamic.mcp.confirmation.enabled', false);
+    app()['env'] = 'production';
+
+    $manager = new ConfirmationTokenManager;
+
+    expect($manager->isEnabled())->toBeFalse();
+});

--- a/tests/Unit/Auth/ResourcePolicyTest.php
+++ b/tests/Unit/Auth/ResourcePolicyTest.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+use Cboxdk\StatamicMcp\Auth\ResourcePolicy;
+use Illuminate\Support\Facades\Config;
+
+beforeEach(function (): void {
+    // Default config: everything open
+    Config::set('statamic.mcp.tools', [
+        'entries' => [
+            'enabled' => true,
+            'resources' => ['read' => ['*'], 'write' => ['*']],
+            'denied_fields' => [],
+        ],
+        'blueprints' => [
+            'enabled' => true,
+            'resources' => ['read' => ['*'], 'write' => ['*']],
+            'denied_fields' => [],
+        ],
+    ]);
+});
+
+// ---------------------------------------------------------------------------
+// canAccess — defaults (everything open)
+// ---------------------------------------------------------------------------
+
+it('allows read access with wildcard default', function (): void {
+    $policy = new ResourcePolicy;
+
+    expect($policy->canAccess('entries', 'blog', 'read'))->toBeTrue();
+});
+
+it('allows write access with wildcard default', function (): void {
+    $policy = new ResourcePolicy;
+
+    expect($policy->canAccess('entries', 'blog', 'write'))->toBeTrue();
+});
+
+// ---------------------------------------------------------------------------
+// canAccess — restricted resources
+// ---------------------------------------------------------------------------
+
+it('allows write when handle matches glob pattern', function (): void {
+    Config::set('statamic.mcp.tools.entries.resources.write', ['blog*', 'pages']);
+
+    $policy = new ResourcePolicy;
+
+    expect($policy->canAccess('entries', 'blog', 'write'))->toBeTrue();
+    expect($policy->canAccess('entries', 'blog-archive', 'write'))->toBeTrue();
+    expect($policy->canAccess('entries', 'pages', 'write'))->toBeTrue();
+});
+
+it('denies write when handle does not match any glob', function (): void {
+    Config::set('statamic.mcp.tools.entries.resources.write', ['blog*', 'pages']);
+
+    $policy = new ResourcePolicy;
+
+    expect($policy->canAccess('entries', 'products', 'write'))->toBeFalse();
+    expect($policy->canAccess('entries', 'my-blog', 'write'))->toBeFalse();
+});
+
+it('allows read even when write is restricted', function (): void {
+    Config::set('statamic.mcp.tools.entries.resources.write', ['blog*']);
+    Config::set('statamic.mcp.tools.entries.resources.read', ['*']);
+
+    $policy = new ResourcePolicy;
+
+    expect($policy->canAccess('entries', 'products', 'read'))->toBeTrue();
+    expect($policy->canAccess('entries', 'products', 'write'))->toBeFalse();
+});
+
+it('denies access when resource list is empty', function (): void {
+    Config::set('statamic.mcp.tools.entries.resources.write', []);
+
+    $policy = new ResourcePolicy;
+
+    expect($policy->canAccess('entries', 'blog', 'write'))->toBeFalse();
+});
+
+// ---------------------------------------------------------------------------
+// canAccess — unconfigured domain falls back to allow all
+// ---------------------------------------------------------------------------
+
+it('allows access for unconfigured domain', function (): void {
+    $policy = new ResourcePolicy;
+
+    expect($policy->canAccess('terms', 'tags', 'write'))->toBeTrue();
+});
+
+// ---------------------------------------------------------------------------
+// getDeniedFields
+// ---------------------------------------------------------------------------
+
+it('returns empty array when no denied fields configured', function (): void {
+    $policy = new ResourcePolicy;
+
+    expect($policy->getDeniedFields('entries'))->toBe([]);
+});
+
+it('returns configured denied fields', function (): void {
+    Config::set('statamic.mcp.tools.entries.denied_fields', ['internal_notes', 'api_key']);
+
+    $policy = new ResourcePolicy;
+
+    expect($policy->getDeniedFields('entries'))->toBe(['internal_notes', 'api_key']);
+});
+
+it('returns empty array for unconfigured domain', function (): void {
+    $policy = new ResourcePolicy;
+
+    expect($policy->getDeniedFields('terms'))->toBe([]);
+});
+
+// ---------------------------------------------------------------------------
+// filterFields — flat data
+// ---------------------------------------------------------------------------
+
+it('strips denied fields from flat data', function (): void {
+    Config::set('statamic.mcp.tools.entries.denied_fields', ['secret', 'internal']);
+
+    $policy = new ResourcePolicy;
+
+    $data = ['title' => 'Hello', 'secret' => 'hidden', 'internal' => 'notes', 'slug' => 'hello'];
+    $filtered = $policy->filterFields('entries', $data);
+
+    expect($filtered)->toBe(['title' => 'Hello', 'slug' => 'hello']);
+});
+
+it('returns data unchanged when no denied fields', function (): void {
+    $policy = new ResourcePolicy;
+
+    $data = ['title' => 'Hello', 'slug' => 'hello'];
+    $filtered = $policy->filterFields('entries', $data);
+
+    expect($filtered)->toBe($data);
+});
+
+// ---------------------------------------------------------------------------
+// filterFields — nested data (Bard/Replicator/Grid)
+// ---------------------------------------------------------------------------
+
+it('strips denied fields from nested arrays recursively', function (): void {
+    Config::set('statamic.mcp.tools.entries.denied_fields', ['secret']);
+
+    $policy = new ResourcePolicy;
+
+    $data = [
+        'title' => 'Post',
+        'content' => [
+            ['type' => 'text', 'secret' => 'hidden', 'text' => 'visible'],
+            ['type' => 'image', 'url' => '/img.png'],
+        ],
+        'secret' => 'top-level-hidden',
+    ];
+
+    $filtered = $policy->filterFields('entries', $data);
+
+    expect($filtered)->toBe([
+        'title' => 'Post',
+        'content' => [
+            ['type' => 'text', 'text' => 'visible'],
+            ['type' => 'image', 'url' => '/img.png'],
+        ],
+    ]);
+});
+
+it('handles deeply nested structures', function (): void {
+    Config::set('statamic.mcp.tools.entries.denied_fields', ['price']);
+
+    $policy = new ResourcePolicy;
+
+    $data = [
+        'title' => 'Product',
+        'sections' => [
+            'main' => [
+                'fields' => [
+                    'name' => 'Widget',
+                    'price' => 99.99,
+                    'details' => [
+                        'price' => 'also hidden',
+                        'description' => 'A widget',
+                    ],
+                ],
+            ],
+        ],
+    ];
+
+    $filtered = $policy->filterFields('entries', $data);
+
+    expect($filtered['sections']['main']['fields'])->not->toHaveKey('price');
+    expect($filtered['sections']['main']['fields']['details'])->not->toHaveKey('price');
+    expect($filtered['sections']['main']['fields']['details']['description'])->toBe('A widget');
+});


### PR DESCRIPTION
## Summary

- Add stateless HMAC-SHA256 confirmation tokens for destructive MCP operations (all deletes + blueprint create/update/delete)
- Add granular resource-level authorization with glob-based allowlists and field-level deny lists
- Environment-aware: confirmation auto-enabled in production, disabled in local/dev/testing

## New services

- **ConfirmationTokenManager** — Stateless two-step confirmation flow, cryptographically bound to tool + arguments
- **ResourcePolicy** — Glob-based resource allowlists (read/write per domain) + recursive field filtering

## Config additions

- `confirmation.enabled` (null = auto-detect by env), `confirmation.ttl` (default 300s)
- Per-domain `resources.read`, `resources.write` (glob patterns), `denied_fields` (field names to strip)

## Test plan

- [x] 31 new unit tests (token generation/validation/expiry/tampering, glob matching, field filtering)
- [x] 972 total tests pass, 0 failures
- [x] PHPStan Level 8 — 0 errors
- [x] Pint — clean formatting
- [ ] Manual verification of two-step confirmation flow via MCP client
- [ ] Verify resource policy blocks restricted collections in production