### PR TITLE
feat: make confirmation-token action list configurable per domain

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,8 +42,10 @@ The addon provides scoped API tokens for fine-grained MCP access control:
 ### Confirmation Tokens
 Destructive MCP operations require a two-step confirmation flow in production:
 - **ConfirmationTokenManager** (`src/Auth/ConfirmationTokenManager.php`) — Stateless HMAC-SHA256 tokens bound to tool + arguments
+- **ConfirmationActionGate** (`src/Auth/ConfirmationActionGate.php`) — Resolves `(domain, action)` → gated? from `confirmation.actions` config
 - **RequiresConfirmation trait** (`src/Mcp/Tools/Concerns/RequiresConfirmation.php`) — Integrated into BaseRouter
-- **Operations requiring confirmation:** All `delete` actions + blueprint `create`/`update`/`delete`
+- **Operations requiring confirmation (defaults):** `delete` on every domain + `create`/`update` on blueprints
+- **Per-domain configurable:** `confirmation.actions.<domain>` lists the actions that trigger the gate. Domains not listed fall back to `default`. `*` gates every action. `[]` disables the gate for that domain. Operators can widen the gate (e.g. `entries => [create, update, delete, publish, unpublish]`) without forking.
 - **Environment-aware:** Auto-enabled in production, disabled in local/dev/testing (configurable via `STATAMIC_MCP_CONFIRMATION_ENABLED`)
 - **CLI bypass:** Confirmation is skipped in CLI context
 
@@ -60,7 +62,7 @@ Granular resource-level access control configured in `config/statamic/mcp.php`:
 2. Token scope? → `TokenScope: {domain}:{read|write}`
 3. Resource allowed? → `ResourcePolicy::canAccess(domain, handle, mode)`
 4. Statamic permissions? → `User::hasPermission()`
-5. Confirmation required? → `ConfirmationTokenManager` (deletes + blueprint writes)
+5. Confirmation required? → `ConfirmationActionGate` (configurable per domain; defaults: deletes + blueprint writes) → `ConfirmationTokenManager`
 6. Field filtering → `ResourcePolicy::filterFields()` on input + output
 
 ### OAuth 2.1 Authorization Server

--- a/config/statamic/mcp.php
+++ b/config/statamic/mcp.php
@@ -125,6 +125,26 @@ return [
     'confirmation' => [
         'enabled' => env('STATAMIC_MCP_CONFIRMATION_ENABLED', null),
         'ttl' => (int) env('STATAMIC_MCP_CONFIRMATION_TTL', 300),
+
+        /*
+        | Per-domain list of actions that require the confirmation-token flow.
+        | Domains not listed fall back to 'default'. An empty array disables
+        | the gate for that domain. The '*' wildcard gates every action.
+        |
+        | Defaults preserve historical behaviour: 'delete' everywhere plus
+        | create/update on blueprints. Operators can widen the gate per
+        | domain — e.g. require confirmation on entries.update — without
+        | forking the package.
+        */
+        'actions' => [
+            'default' => ['delete'],
+            'blueprints' => ['create', 'update', 'delete'],
+            // 'entries' => ['create', 'update', 'delete', 'publish', 'unpublish'],
+            // 'globals' => ['update'],
+            // 'terms'   => ['create', 'update', 'delete'],
+            // 'assets'  => ['upload', 'update', 'delete', 'move', 'copy'],
+            // 'users'   => ['create', 'update', 'delete', 'assign-role'],
+        ],
     ],
 
     /*

--- a/docs/superpowers/specs/2026-04-17-confirmation-tokens-and-resource-policy-design.md
+++ b/docs/superpowers/specs/2026-04-17-confirmation-tokens-and-resource-policy-design.md
@@ -72,10 +72,20 @@ Agent                           MCP Server
 'confirmation' => [
     'enabled' => env('STATAMIC_MCP_CONFIRMATION_ENABLED', null), // null = auto-detect
     'ttl' => env('STATAMIC_MCP_CONFIRMATION_TTL', 300),
+
+    // Per-domain gate list. Domains not listed fall back to 'default'.
+    // '*' gates every action; [] disables the gate for that domain.
+    'actions' => [
+        'default'    => ['delete'],
+        'blueprints' => ['create', 'update', 'delete'],
+        // e.g. 'entries' => ['create', 'update', 'delete', 'publish', 'unpublish'],
+    ],
 ],
 ```
 
 **Environment-aware default:** When `enabled` is `null` (the default), confirmation is automatically enabled in `production` and disabled in `local`, `development`, `testing`, and `staging`. This matches the existing pattern in `EnsureSecureTransport` middleware which skips HTTPS enforcement in non-production environments. Explicitly setting `true` or `false` overrides the auto-detection.
+
+**Configurable action list:** `confirmation.actions` maps domain handle → gated actions. Resolved by `ConfirmationActionGate::gates($domain, $action)` inside the `RequiresConfirmation` trait. Shipped defaults reproduce the original behaviour (delete everywhere + blueprint writes), so existing consumers see no change. Operators can widen the gate per domain (e.g. require confirmation on `entries.update`) without forking the package.
 
 ### Public API
 

--- a/src/Auth/ConfirmationActionGate.php
+++ b/src/Auth/ConfirmationActionGate.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cboxdk\StatamicMcp\Auth;
+
+/**
+ * Resolves whether a (domain, action) pair requires the confirmation-token
+ * flow, based on `statamic.mcp.confirmation.actions`.
+ *
+ * Domains not listed fall back to `default`, which itself defaults to
+ * `['delete']`. The `*` wildcard gates every action in the domain.
+ */
+final class ConfirmationActionGate
+{
+    public static function gates(string $domain, string $action): bool
+    {
+        /** @var array<string, array<int, string>> $map */
+        $map = config('statamic.mcp.confirmation.actions', []);
+
+        $gated = $map[$domain] ?? $map['default'] ?? ['delete'];
+
+        return in_array('*', $gated, true) || in_array($action, $gated, true);
+    }
+}

--- a/src/Mcp/Tools/Concerns/RequiresConfirmation.php
+++ b/src/Mcp/Tools/Concerns/RequiresConfirmation.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Cboxdk\StatamicMcp\Mcp\Tools\Concerns;
 
+use Cboxdk\StatamicMcp\Auth\ConfirmationActionGate;
 use Cboxdk\StatamicMcp\Auth\ConfirmationTokenManager;
 
 /**
@@ -17,20 +18,14 @@ trait RequiresConfirmation
 {
     /**
      * Check if the given action requires confirmation for this router.
+     *
+     * Gate list comes from `statamic.mcp.confirmation.actions`. A domain
+     * not listed falls back to `default`, which itself defaults to
+     * `['delete']`. The `*` wildcard gates every action in the domain.
      */
     protected function requiresConfirmation(string $action): bool
     {
-        // All routers: delete requires confirmation
-        if ($action === 'delete') {
-            return true;
-        }
-
-        // BlueprintsRouter: create and update also require confirmation
-        if ($this->getDomain() === 'blueprints' && in_array($action, ['create', 'update'], true)) {
-            return true;
-        }
-
-        return false;
+        return ConfirmationActionGate::gates($this->getDomain(), $action);
     }
 
     /**

--- a/tests/Feature/ConfirmationActionsConfigTest.php
+++ b/tests/Feature/ConfirmationActionsConfigTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+use Cboxdk\StatamicMcp\Auth\ConfirmationActionGate;
+use Cboxdk\StatamicMcp\Mcp\Tools\Routers\EntriesRouter;
+use Illuminate\Support\Facades\Config;
+
+beforeEach(function (): void {
+    Config::set('app.key', 'base64:' . base64_encode(random_bytes(32)));
+    // Mirror the shipped defaults so each test starts from a known baseline.
+    Config::set('statamic.mcp.confirmation.actions', [
+        'default' => ['delete'],
+        'blueprints' => ['create', 'update', 'delete'],
+    ]);
+    Config::set('statamic.mcp.confirmation.enabled', true);
+    Config::set('statamic.mcp.confirmation.ttl', 300);
+});
+
+// ---------------------------------------------------------------------------
+// Defaults (regression guards — must not change without a major version bump)
+// ---------------------------------------------------------------------------
+
+it('gates delete on domains using the default list', function (): void {
+    expect(ConfirmationActionGate::gates('entries', 'delete'))->toBeTrue();
+});
+
+it('does NOT gate update on entries by default', function (): void {
+    expect(ConfirmationActionGate::gates('entries', 'update'))->toBeFalse();
+});
+
+it('gates create/update/delete on blueprints (backwards-compat regression guard)', function (): void {
+    expect(ConfirmationActionGate::gates('blueprints', 'create'))->toBeTrue();
+    expect(ConfirmationActionGate::gates('blueprints', 'update'))->toBeTrue();
+    expect(ConfirmationActionGate::gates('blueprints', 'delete'))->toBeTrue();
+});
+
+// ---------------------------------------------------------------------------
+// Explicit per-domain configuration
+// ---------------------------------------------------------------------------
+
+it('honours explicit per-domain gating for entries.update', function (): void {
+    Config::set('statamic.mcp.confirmation.actions.entries', ['update']);
+
+    expect(ConfirmationActionGate::gates('entries', 'update'))->toBeTrue();
+    // Not in the list → not gated.
+    expect(ConfirmationActionGate::gates('entries', 'delete'))->toBeFalse();
+});
+
+it('disables all gates on a domain when set to an empty array', function (): void {
+    Config::set('statamic.mcp.confirmation.actions.entries', []);
+
+    expect(ConfirmationActionGate::gates('entries', 'delete'))->toBeFalse();
+    expect(ConfirmationActionGate::gates('entries', 'update'))->toBeFalse();
+    expect(ConfirmationActionGate::gates('entries', 'create'))->toBeFalse();
+});
+
+// ---------------------------------------------------------------------------
+// Fallback behaviour
+// ---------------------------------------------------------------------------
+
+it('falls back to the default list for domains not explicitly listed', function (): void {
+    // No 'terms' key in config — should use 'default'.
+    expect(ConfirmationActionGate::gates('terms', 'delete'))->toBeTrue();
+    expect(ConfirmationActionGate::gates('terms', 'update'))->toBeFalse();
+});
+
+it('gates every action when the domain list contains the wildcard', function (): void {
+    Config::set('statamic.mcp.confirmation.actions.entries', ['*']);
+
+    expect(ConfirmationActionGate::gates('entries', 'list'))->toBeTrue();
+    expect(ConfirmationActionGate::gates('entries', 'create'))->toBeTrue();
+    expect(ConfirmationActionGate::gates('entries', 'update'))->toBeTrue();
+    expect(ConfirmationActionGate::gates('entries', 'delete'))->toBeTrue();
+    expect(ConfirmationActionGate::gates('entries', 'publish'))->toBeTrue();
+});
+
+// ---------------------------------------------------------------------------
+// handleConfirmation() short-circuits (env + CLI)
+// ---------------------------------------------------------------------------
+
+it('short-circuits handleConfirmation when confirmation.enabled is false', function (): void {
+    Config::set('statamic.mcp.confirmation.enabled', false);
+
+    $router = new class extends EntriesRouter
+    {
+        /**
+         * @param  array<string, mixed>  $arguments
+         *
+         * @return array<string, mixed>|null
+         */
+        public function callHandleConfirmation(string $action, array $arguments): ?array
+        {
+            return $this->handleConfirmation($action, $arguments);
+        }
+    };
+
+    $response = $router->callHandleConfirmation('delete', ['id' => 'abc']);
+
+    expect($response)->toBeNull();
+});
+
+it('short-circuits handleConfirmation in CLI context', function (): void {
+    Config::set('statamic.mcp.confirmation.enabled', true);
+
+    $router = new class extends EntriesRouter
+    {
+        /**
+         * @param  array<string, mixed>  $arguments
+         *
+         * @return array<string, mixed>|null
+         */
+        public function callHandleConfirmation(string $action, array $arguments): ?array
+        {
+            return $this->handleConfirmation($action, $arguments);
+        }
+    };
+
+    // runningInConsole() is true under Pest — gate should still short-circuit.
+    $response = $router->callHandleConfirmation('delete', ['id' => 'abc']);
+
+    expect($response)->toBeNull();
+});


### PR DESCRIPTION
## Problem

`RequiresConfirmation::requiresConfirmation()` hardcoded the set of actions that triggered the confirmation-token flow to `delete` (everywhere) and `create`/`update` (blueprints only). Setting `STATAMIC_MCP_CONFIRMATION_ENABLED=true` in production therefore gave operators **no way** to gate other destructive actions — `entries.update`, `entries.publish`, `terms.update`, `globals.update`, `assets.upload`, `users.assign-role`, etc. — without forking the package.

Observed failure that motivated this: an LLM silently ran `statamic-entries action=update` on a live entry and corrupted a Bard `table` field (cells written as `{value: …}` objects; the CP rendered `[object Object]`). A confirmation step would have caught it. PR #25 closes the write-side gap in the sanitizer; this PR closes the policy-side gap so operators can require an extra approval step at all.

## Change

Introduce a new config block `statamic.mcp.confirmation.actions` — a per-domain action list resolved by a small new helper `ConfirmationActionGate::gates(\$domain, \$action)`. The trait method just delegates to it.

```php
'confirmation' => [
    'enabled' => env('STATAMIC_MCP_CONFIRMATION_ENABLED', null),
    'ttl'     => (int) env('STATAMIC_MCP_CONFIRMATION_TTL', 300),

    'actions' => [
        'default'    => ['delete'],
        'blueprints' => ['create', 'update', 'delete'],
        // 'entries' => ['create', 'update', 'delete', 'publish', 'unpublish'],
        // 'globals' => ['update'],
    ],
],
```

Semantics:
- Domains not listed fall back to `default`.
- `*` wildcard gates every action in a domain.
- `[]` disables the gate for that domain.

## Backwards compatibility

The shipped defaults reproduce the exact behaviour of the previous hardcoded rule:
- `default => [delete]` → every router still gates `delete`.
- `blueprints => [create, update, delete]` → blueprint writes still gated.

Consumers not touching `confirmation.actions` see no change. A regression test pins this explicitly.

## Files changed

- `config/statamic/mcp.php` — new `actions` key under `confirmation`.
- `src/Auth/ConfirmationActionGate.php` — new helper (static, stateless).
- `src/Mcp/Tools/Concerns/RequiresConfirmation.php` — delegates to the gate.
- `tests/Feature/ConfirmationActionsConfigTest.php` — 9 Pest cases.
- `CLAUDE.md` — updated Confirmation Tokens and Authorization Evaluation Order sections.
- `docs/superpowers/specs/2026-04-17-confirmation-tokens-and-resource-policy-design.md` — documented the configurable action list.

## Test matrix (all 9 passing)

- [x] default config gates `entries.delete`
- [x] default config does NOT gate `entries.update`
- [x] default config gates `blueprints.create`/`update`/`delete` (regression guard)
- [x] explicit `entries => [update]` gates `entries.update` only
- [x] explicit `entries => []` disables all gates on entries
- [x] missing domain falls back to `default`
- [x] `*` wildcard gates every action
- [x] `confirmation.enabled=false` short-circuits regardless of gate list
- [x] CLI context short-circuits regardless of gate list

## Validation

- [x] `./vendor/bin/pest tests/Feature/ConfirmationActionsConfigTest.php` — 9 passed
- [x] `./vendor/bin/pest` — full suite, 981 passed
- [x] `./vendor/bin/phpstan analyse` — clean at Level 8
- [x] `./vendor/bin/pint` — clean

## Non-goals

- No per-resource (collection-level) gating — `ResourcePolicy` already covers that axis.
- No env-driven CSV — nested config is clearer and avoids string parsing.
- No auto-inference from tool annotations (`#[IsReadOnly]` etc.) — explicit config is more auditable.