### PR TITLE
fix(cp): cast user id to string in ResolvesUserId trait

### DIFF
--- a/src/Http/Controllers/CP/Concerns/ResolvesUserId.php
+++ b/src/Http/Controllers/CP/Concerns/ResolvesUserId.php
@@ -15,9 +15,9 @@ trait ResolvesUserId
     {
         $user = User::current();
 
-        /** @var string $userId */
-        $userId = $user ? $user->id() : '';
-
-        return $userId;
+        // Cast to string: Statamic's User->id() returns string under the file
+        // users driver but int under the Eloquent driver. The trait's return
+        // type contract (and downstream token storage) requires string.
+        return $user ? (string) $user->id() : '';
     }
 }

--- a/tests/Unit/Http/Controllers/CP/Concerns/ResolvesUserIdTest.php
+++ b/tests/Unit/Http/Controllers/CP/Concerns/ResolvesUserIdTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+use Cboxdk\StatamicMcp\Http\Controllers\CP\Concerns\ResolvesUserId;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Statamic\Contracts\Auth\User as StatamicUserContract;
+use Statamic\Facades\User;
+
+/**
+ * Concrete subject that exposes the private trait method for direct testing.
+ */
+class ResolvesUserIdSubject
+{
+    use ResolvesUserId {
+        resolveUserId as public;
+    }
+}
+
+it('returns the user id as a string when User->id() returns an int (Eloquent driver)', function () {
+    $user = Mockery::mock(StatamicUserContract::class, Authenticatable::class);
+    $user->shouldReceive('id')->andReturn(42);
+
+    User::shouldReceive('current')->andReturn($user);
+
+    $result = (new ResolvesUserIdSubject)->resolveUserId();
+
+    expect($result)->toBe('42');
+});
+
+it('returns the user id as a string when User->id() returns a string (file driver)', function () {
+    $user = Mockery::mock(StatamicUserContract::class, Authenticatable::class);
+    $user->shouldReceive('id')->andReturn('019357a0-7f6a-7000-a1b2-deadbeef0000');
+
+    User::shouldReceive('current')->andReturn($user);
+
+    $result = (new ResolvesUserIdSubject)->resolveUserId();
+
+    expect($result)->toBe('019357a0-7f6a-7000-a1b2-deadbeef0000');
+});
+
+it('returns an empty string when no user is authenticated', function () {
+    User::shouldReceive('current')->andReturn(null);
+
+    $result = (new ResolvesUserIdSubject)->resolveUserId();
+
+    expect($result)->toBe('');
+});


### PR DESCRIPTION
The trait declares a `: string` return type, but Statamic's `User::current()->id()` returns int under the Eloquent users driver (only string under the file driver). With `declare(strict_types=1)` this raises a TypeError on every request that lands in DashboardController::index() or TokenController, breaking the entire `/cp/mcp` panel for sites using Statamic's Eloquent driver.

Cast at the trait boundary so the contract holds regardless of driver. The PHPDoc `@var string` annotation was incorrect under Eloquent — removed in favour of an explicit cast.

Adds a Pest unit test that mocks `User::current()` to return both int and string ids, covering the file driver, the Eloquent driver, and the unauthenticated case.

## Description

<!-- Brief description of what this PR does -->

## Type of Change

<!-- Mark with an 'x' -->

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔧 Tool enhancement
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring

## Related Issue

<!-- Link any related issues - use "Fixes #123" to auto-close -->

Fixes #

## Testing

<!-- How did you test this? -->

- [ ] Tests pass (`composer test`)
- [ ] Code quality checks pass (`composer quality`)
- [ ] Tested manually with Statamic

### Environment
- Statamic: 
- Laravel: 
- PHP: 

## Checklist

- [ ] My code follows the project style
- [ ] I've added/updated tests if needed
- [ ] Tool responses follow the standard format

## Notes

<!-- Any additional context or screenshots -->

---

*Thanks for contributing to this alpha project! 🙏*