### PR TITLE
Fix Eloquent user IDs and update MCP dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A comprehensive MCP (Model Context Protocol) server for Statamic CMS v6 that pro
 - PHP 8.3+
 - Laravel 12+
 - Statamic 6.6+
-- Laravel MCP ^0.6
+- Laravel MCP ^0.6 || ^0.7
 
 ## Installation
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -7,7 +7,7 @@
 | PHP | ^8.3 | ^8.3 |
 | Statamic | ^5.65 \| ^6.0 | ^6.6 |
 | Laravel | ^11.0 \| ^12.0 | ^12.0 \| ^13.0 (via Statamic v6) |
-| Laravel MCP | ^0.4.1 \| ^0.5 | ^0.6 |
+| Laravel MCP | ^0.4.1 \| ^0.5 | ^0.6 \|\| ^0.7 |
 | Symfony YAML | ^7.3 | ^7.0 \| ^8.0 |
 
 **Statamic v5 support has been removed.** If you are on Statamic v5, stay on v1.x.

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "^8.3",
         "statamic/cms": "^6.6",
-        "laravel/mcp": "^0.6",
+        "laravel/mcp": "^0.6 || ^0.7",
         "symfony/yaml": "^7.0 || ^8.0"
     },
     "require-dev": {

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -11,7 +11,7 @@ weight: 1
 - **PHP** 8.3 or higher
 - **Statamic CMS** v6.6+
 - **Laravel** 12.0+
-- **laravel/mcp** ^0.6 (installed automatically as a dependency)
+- **laravel/mcp** ^0.6 || ^0.7 (installed automatically as a dependency)
 
 ## Install via Composer
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -74,7 +74,7 @@ The server registers a set of domain routers — each handling a specific Statam
 - **PHP** 8.3+
 - **Statamic** v6.6+
 - **Laravel** 12.0+
-- **laravel/mcp** ^0.6
+- **laravel/mcp** ^0.6 || ^0.7
 
 ## Quick Links
 

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -666,7 +666,7 @@ class InstallCommand extends Command
 # Statamic MCP Server v2.0 Integration
 
 This project uses Statamic MCP Server v2.0 for enhanced AI-assisted development.
-Requires Statamic v6+ and laravel/mcp v0.6+.
+Requires Statamic v6+ and laravel/mcp ^0.6 or ^0.7.
 
 ## MCP Server Configuration
 - Command: php artisan mcp:start statamic
@@ -801,7 +801,7 @@ MARKDOWN;
 # Statamic MCP Guidelines (v2.0)
 
 This file provides AI assistants with comprehensive understanding of the Statamic MCP Server v2.0 capabilities.
-Requires Statamic v6+ and laravel/mcp v0.6+.
+Requires Statamic v6+ and laravel/mcp ^0.6 or ^0.7.
 
 ## MCP Server Overview
 

--- a/src/Http/Controllers/CP/Concerns/ResolvesUserId.php
+++ b/src/Http/Controllers/CP/Concerns/ResolvesUserId.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Cboxdk\StatamicMcp\Http\Controllers\CP\Concerns;
 
+use Cboxdk\StatamicMcp\Support\UserIds;
 use Statamic\Facades\User;
 
 trait ResolvesUserId
@@ -15,9 +16,6 @@ trait ResolvesUserId
     {
         $user = User::current();
 
-        /** @var string $userId */
-        $userId = $user ? $user->id() : '';
-
-        return $userId;
+        return $user ? UserIds::normalize($user->id()) : '';
     }
 }

--- a/src/Http/Controllers/OAuth/AuthorizeController.php
+++ b/src/Http/Controllers/OAuth/AuthorizeController.php
@@ -12,6 +12,7 @@ use Cboxdk\StatamicMcp\OAuth\Cimd\CimdValidationException;
 use Cboxdk\StatamicMcp\OAuth\Contracts\OAuthDriver;
 use Cboxdk\StatamicMcp\OAuth\Exceptions\OAuthException;
 use Cboxdk\StatamicMcp\OAuth\OAuthClient;
+use Cboxdk\StatamicMcp\Support\UserIds;
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -277,8 +278,7 @@ class AuthorizeController extends Controller
             ])));
         }
 
-        /** @var string $userId */
-        $userId = $user->id();
+        $userId = UserIds::normalize($user->id());
 
         // Get originally requested scopes from the hidden form field (set by show())
         /** @var string $originalScope */

--- a/src/Support/UserIds.php
+++ b/src/Support/UserIds.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cboxdk\StatamicMcp\Support;
+
+class UserIds
+{
+    public static function normalize(mixed $userId): string
+    {
+        return is_scalar($userId) || $userId === null ? (string) $userId : '';
+    }
+}

--- a/tests/Unit/Http/Controllers/CP/ResolvesUserIdTest.php
+++ b/tests/Unit/Http/Controllers/CP/ResolvesUserIdTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cboxdk\StatamicMcp\Tests\Unit\Http\Controllers\CP;
+
+use Cboxdk\StatamicMcp\Http\Controllers\CP\Concerns\ResolvesUserId;
+use Cboxdk\StatamicMcp\Tests\TestCase;
+use Illuminate\Database\Eloquent\Model;
+use ReflectionMethod;
+use Statamic\Auth\Eloquent\User as EloquentUser;
+use Statamic\Facades\User;
+
+class ResolvesUserIdTest extends TestCase
+{
+    public function test_resolves_integer_user_ids_as_strings(): void
+    {
+        User::shouldReceive('current')
+            ->once()
+            ->andReturn($this->makeEloquentUserWithId(1));
+
+        $this->assertSame('1', $this->resolveCurrentUserId());
+    }
+
+    public function test_preserves_string_user_ids(): void
+    {
+        User::shouldReceive('current')
+            ->once()
+            ->andReturn($this->makeEloquentUserWithId('flat-file-user'));
+
+        $this->assertSame('flat-file-user', $this->resolveCurrentUserId());
+    }
+
+    public function test_resolves_missing_user_as_empty_string(): void
+    {
+        User::shouldReceive('current')
+            ->once()
+            ->andReturn(null);
+
+        $this->assertSame('', $this->resolveCurrentUserId());
+    }
+
+    private function resolveCurrentUserId(): string
+    {
+        $controller = new class
+        {
+            use ResolvesUserId;
+        };
+
+        $method = new ReflectionMethod($controller, 'resolveUserId');
+        $method->setAccessible(true);
+
+        return $method->invoke($controller);
+    }
+
+    private function makeEloquentUserWithId(int|string $id): EloquentUser
+    {
+        $model = new class extends Model
+        {
+            public $timestamps = false;
+
+            public $incrementing = false;
+
+            protected $keyType = 'string';
+
+            protected $guarded = [];
+        };
+        $model->setAttribute('id', $id);
+
+        return (new EloquentUser)->model($model);
+    }
+}

--- a/tests/Unit/Support/UserIdsTest.php
+++ b/tests/Unit/Support/UserIdsTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cboxdk\StatamicMcp\Tests\Unit\Support;
+
+use Cboxdk\StatamicMcp\Support\UserIds;
+use Cboxdk\StatamicMcp\Tests\TestCase;
+
+class UserIdsTest extends TestCase
+{
+    public function test_normalizes_integer_user_ids_from_eloquent_driver(): void
+    {
+        $this->assertSame('1', UserIds::normalize(1));
+    }
+
+    public function test_preserves_string_user_ids_from_flat_file_driver(): void
+    {
+        $this->assertSame('flat-file-user', UserIds::normalize('flat-file-user'));
+    }
+}


### PR DESCRIPTION
## What changed

- Normalize Statamic user IDs before storing or filtering MCP tokens so Eloquent integer IDs satisfy strict string contracts.
- Apply the same normalization in the OAuth authorization flow.
- Widen the laravel/mcp dependency to support ^0.6 and ^0.7, and update docs/install guidance to match.
- Add regression tests for integer Eloquent IDs, string IDs, and missing current users.

## Why

Sites using Statamic Eloquent users can return integer user IDs, which caused a TypeError in the MCP dashboard under strict types. Fresh installs can also be blocked by the older laravel/mcp constraint when using newer MCP packages.

Fixes #31.

## Verification

- composer validate --strict
- vendor/bin/pint --test tests/Unit/Http/Controllers/CP/ResolvesUserIdTest.php
- vendor/bin/pest tests/Unit/Support/UserIdsTest.php tests/Unit/Http/Controllers/CP/ResolvesUserIdTest.php tests/E2E/UserDashboardTest.php tests/E2E/TokenLifecycleTest.php