### PR TITLE
Support laravel/mcp ^0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.8.0] - 2026-07-29
+
+### Changed
+- **laravel/mcp ^0.9 support** — Widens the dependency constraint to `^0.6 || ^0.7 || ^0.8 || ^0.9`. The 0.9 breaking changes are client-side only (the `Laravel\Mcp\Client\Contracts\Transport` contract gained `setProtocolVersion()`, and the MCP *client* now only negotiates `2025-11-25`/`2025-06-18`); this addon ships a server and does not implement either, so no code changes were needed. Server-side gains come for free: stricter JSON-RPC `params`/`arguments` validation (`-32602` on non-object payloads), a `CursorPaginator` fix for negative cursor offsets, and hardened OAuth dynamic client registration
+
 ## [2.7.0] - 2026-07-05
 
 ### Changed
@@ -348,6 +353,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Laravel MCP v0.2.0 integration
 - Comprehensive test suite
 
+[2.8.0]: https://github.com/cboxdk/statamic-mcp/compare/v2.7.0...v2.8.0
+[2.7.0]: https://github.com/cboxdk/statamic-mcp/compare/v2.6.1...v2.7.0
 [2.6.1]: https://github.com/cboxdk/statamic-mcp/compare/v2.6.0...v2.6.1
 [2.6.0]: https://github.com/cboxdk/statamic-mcp/compare/v2.5.0...v2.6.0
 [2.5.0]: https://github.com/cboxdk/statamic-mcp/compare/v2.4.0...v2.5.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,14 +4,14 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is a Statamic addon that functions as an MCP (Model Context Protocol) server, built on top of Laravel's MCP server. The addon extends Statamic CMS v6.6+ and requires `laravel/mcp` ^0.6 || ^0.7 || ^0.8 as a runtime dependency. It includes scoped API token authentication, a Vue 3 CP dashboard, and web MCP endpoints.
+This is a Statamic addon that functions as an MCP (Model Context Protocol) server, built on top of Laravel's MCP server. The addon extends Statamic CMS v6.6+ and requires `laravel/mcp` ^0.6 || ^0.7 || ^0.8 || ^0.9 as a runtime dependency. It includes scoped API token authentication, a Vue 3 CP dashboard, and web MCP endpoints.
 
 ## Key Dependencies
 
 - **PHP**: ^8.3
 - **Statamic CMS**: ^6.6 (v6 only — v5 support was removed in v2.0)
 - **Laravel**: ^12.0 || ^13.0 (via Statamic v6)
-- **Laravel MCP**: ^0.6 || ^0.7 || ^0.8 (required - must be in `require` section, not `require-dev`)
+- **Laravel MCP**: ^0.6 || ^0.7 || ^0.8 || ^0.9 (required - must be in `require` section, not `require-dev`)
 - **Orchestra Testbench**: ^10.0 || ^11.0 (dev dependency for testing)
 - **Pest**: ^4.1 (stable release with PHP 8.3 requirement)
 - **Symfony YAML**: ^7.0 || ^8.0 (for YAML processing)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A comprehensive MCP (Model Context Protocol) server for Statamic CMS v6 that pro
 - PHP 8.3+
 - Laravel 12+
 - Statamic 6.6+
-- Laravel MCP ^0.6 || ^0.7 || ^0.8
+- Laravel MCP ^0.6 || ^0.7 || ^0.8 || ^0.9
 
 ## Installation
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -7,7 +7,7 @@
 | PHP | ^8.3 | ^8.3 |
 | Statamic | ^5.65 \| ^6.0 | ^6.6 |
 | Laravel | ^11.0 \| ^12.0 | ^12.0 \| ^13.0 (via Statamic v6) |
-| Laravel MCP | ^0.4.1 \| ^0.5 | ^0.6 \|\| ^0.7 \|\| ^0.8 |
+| Laravel MCP | ^0.4.1 \| ^0.5 | ^0.6 \|\| ^0.7 \|\| ^0.8 \|\| ^0.9 |
 | Symfony YAML | ^7.3 | ^7.0 \| ^8.0 |
 
 **Statamic v5 support has been removed.** If you are on Statamic v5, stay on v1.x.

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "^8.3",
         "statamic/cms": "^6.6",
-        "laravel/mcp": "^0.6 || ^0.7 || ^0.8",
+        "laravel/mcp": "^0.6 || ^0.7 || ^0.8 || ^0.9",
         "symfony/yaml": "^7.0 || ^8.0"
     },
     "require-dev": {

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -11,7 +11,7 @@ weight: 1
 - **PHP** 8.3 or higher
 - **Statamic CMS** v6.6+
 - **Laravel** 12.0+
-- **laravel/mcp** ^0.6 || ^0.7 || ^0.8 (installed automatically as a dependency)
+- **laravel/mcp** ^0.6 || ^0.7 || ^0.8 || ^0.9 (installed automatically as a dependency)
 
 ## Install via Composer
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -74,7 +74,7 @@ The server registers a set of domain routers — each handling a specific Statam
 - **PHP** 8.3+
 - **Statamic** v6.6+
 - **Laravel** 12.0+
-- **laravel/mcp** ^0.6 || ^0.7 || ^0.8
+- **laravel/mcp** ^0.6 || ^0.7 || ^0.8 || ^0.9
 
 ## Quick Links
 

--- a/src/Mcp/Servers/StatamicMcpServer.php
+++ b/src/Mcp/Servers/StatamicMcpServer.php
@@ -26,7 +26,7 @@ class StatamicMcpServer extends Server
 {
     protected string $name = 'Statamic MCP Server';
 
-    protected string $version = '2.7.0';
+    protected string $version = '2.8.0';
 
     protected string $instructions = <<<'MARKDOWN'
         You are connected to a Statamic CMS site via MCP. Use these tools to manage content, blueprints, assets, users, and system settings.


### PR DESCRIPTION
## What

Widens the `laravel/mcp` constraint to `^0.6 || ^0.7 || ^0.8 || ^0.9` and cuts v2.8.0.

## Why no code changes were needed

Both breaking changes in laravel/mcp v0.9.0 are **client-side**, and this addon ships a *server*:

- `Laravel\Mcp\Client\Contracts\Transport` now requires `setProtocolVersion(string $version): void`. We use `Laravel\Mcp\Server\Contracts\Transport`, which is unchanged.
- The MCP *client* now validates against `ProtocolVersion::clientSupported()` (`2025-11-25`, `2025-06-18` only). `ProtocolVersion::supported()` — what the server accepts — is unchanged, so our web endpoint still negotiates all four versions.

Confirmed by grep: no references to `Laravel\Mcp\Client\*`, `WebClient`, `ProtocolVersion`, or `Registrar::oauthRoutes()` anywhere in `src/` or `tests/`. Our OAuth 2.1 server is our own implementation, so the changes to laravel/mcp's `OAuthRegisterController` don't apply either.

## What we get for free

- **Stricter JSON-RPC validation** (v0.9.1) — non-object `params`/`arguments` are rejected with `-32602` instead of slipping through.
- **`CursorPaginator` fix** — negative cursor offsets no longer return trailing items (clamped with `max(0, …)`).
- Hardened OAuth dynamic client registration and `#[SensitiveParameter]` on secret-bearing parameters.

## Verification

Ran locally against `laravel/mcp v0.9.1`:

- `pest` — **1060 passed** (5437 assertions), including the full OAuth suite (DCR, CIMD, refresh, revocation)
- `phpstan analyse` — **no errors** at level 9 (needs `--memory-limit=2G` locally; the default 128M crashes the parallel worker)
- `pint --test` — passed

## Changes

- `composer.json` — constraint widened
- `src/Mcp/Servers/StatamicMcpServer.php` — version `2.7.0` → `2.8.0`
- `CHANGELOG.md` — 2.8.0 entry, plus the missing 2.7.0/2.8.0 compare links
- `README.md`, `UPGRADE.md`, `CLAUDE.md`, `docs/introduction.md`, `docs/getting-started/installation.md` — version references