### PR TITLE
Fix hanging release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,13 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-    
+
     name: Create Release
-    
+
+    # Without this, a hanging step burns the 6h default job timeout before
+    # anyone finds out the release failed.
+    timeout-minutes: 30
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -46,27 +50,41 @@ jobs:
         if: steps.check_release.outputs.exists == 'false'
         run: echo "APP_KEY=base64:SGk1bGF2ZWw=" > .env
 
+      # Deliberately NOT --parallel: the suite is not parallel-safe, because
+      # Statamic's AddonTestCase points every Stache store at one shared
+      # tests/__fixtures__ directory that workers then delete out from under
+      # each other. This mirrors the Tests workflow that gates pull requests.
       - name: Run tests
         if: steps.check_release.outputs.exists == 'false'
-        run: ./vendor/bin/pest --parallel
+        run: ./vendor/bin/pest
+        env:
+          DB_CONNECTION: sqlite
 
-      - name: Fix code formatting
+      - name: Check code formatting
         if: steps.check_release.outputs.exists == 'false'
-        run: ./vendor/bin/pint
+        run: ./vendor/bin/pint --test
 
       - name: Run static analysis
         if: steps.check_release.outputs.exists == 'false'
-        run: ./vendor/bin/phpstan analyse
+        run: ./vendor/bin/phpstan analyse --memory-limit=1G
 
       - name: Generate changelog
         if: steps.check_release.outputs.exists == 'false'
         id: changelog
         run: |
+          # CHANGELOG.md headings carry no "v" prefix (## [2.8.0]), the tag does (v2.8.0).
+          version="${GITHUB_REF_NAME#v}"
+
           if [ -f CHANGELOG.md ]; then
-            # Extract changelog for this version
-            awk '/^## \[/{if(p) exit; if(/\[${{ github.ref_name }}\]/) p=1; next} p' CHANGELOG.md > release_notes.txt
-          else
-            echo "Automated release for ${{ github.ref_name }}" > release_notes.txt
+            awk -v version="$version" '
+              /^## \[/ { if (found) exit; if (index($0, "[" version "]")) found = 1; next }
+              found
+            ' CHANGELOG.md > release_notes.txt
+          fi
+
+          # Never publish an empty release body.
+          if [ ! -s release_notes.txt ]; then
+            echo "Automated release for ${GITHUB_REF_NAME}" > release_notes.txt
           fi
 
       - name: Create Release

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   code-quality:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     name: Code Quality
 
     steps:
@@ -49,10 +50,11 @@ jobs:
           branch: ${{ github.ref }}
 
       - name: Run static analysis
-        run: ./vendor/bin/phpstan analyse --error-format=github
+        run: ./vendor/bin/phpstan analyse --error-format=github --memory-limit=1G
 
   test-sqlite:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: code-quality
     strategy:
       fail-fast: false
@@ -90,6 +92,7 @@ jobs:
 
   test-mysql:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: code-quality
     strategy:
       fail-fast: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Release workflow no longer hangs** — The release job ran `pest --parallel`, which is not parallel-safe: `Statamic\Testing\AddonTestCase` points every Stache store, and `PreventsSavingStacheItemsToDisk`'s `dev-null` directory, at one shared `tests/__fixtures__` path, so ParaTest workers deleted each other's fixtures. This produced ~34 spurious failures or, when workers collided on the file-store `flock()` calls, a hang that burned the 6h job timeout (v2.6.1 and v2.8.0 both died this way, and both releases had to be published by hand). The release job now runs the same single-process `pest` that gates pull requests, and every job has an explicit `timeout-minutes` so a hang fails in minutes instead of hours
+- **Release notes are no longer empty** — The changelog extraction matched `[v2.8.0]` against headings written as `[2.8.0]`, so it never selected anything. The tag's `v` prefix is now stripped, with a fallback message if the section is missing
+- **Release workflow verifies formatting instead of rewriting it** — The `Fix code formatting` step ran Pint in fix mode and discarded the result; it now runs `pint --test` and fails on violations
+
+### Changed
+- **`composer stan` passes `--memory-limit=1G`** — PHPStan crashed its parallel worker at PHP's default 128M
+- **Removed the `composer test:parallel` script** — It could not work for the reason above; use `composer test`
+
 ## [2.8.0] - 2026-07-29
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,14 @@ composer test:coverage
 ./vendor/bin/pest --watch
 ```
 
+**Do not run the suite with `--parallel`.** It is not parallel-safe and there is no
+`test:parallel` script for that reason. `Statamic\Testing\AddonTestCase` hardcodes every
+Stache store directory — and `PreventsSavingStacheItemsToDisk`'s `dev-null` directory — to
+a single shared `tests/__fixtures__/…` path, so ParaTest workers delete and recreate each
+other's fixture directories mid-test. The result is ~34 spurious failures (`mkdir(): File
+exists`, missing collection YAML) and, when workers collide on the file-store `flock()`
+calls, a hang that never terminates. Always use the single-process `./vendor/bin/pest`.
+
 ### Code Quality
 ```bash
 # Format code with Laravel Pint
@@ -160,14 +168,15 @@ composer pint
 composer pint:test
 
 # Run static analysis with PHPStan/Larastan
-./vendor/bin/phpstan analyse
+# The memory limit is required — the default 128M crashes the parallel worker
+./vendor/bin/phpstan analyse --memory-limit=1G
 composer stan
 
 # Run all quality checks (format + analysis + tests)
 composer quality
 ```
 
-**IMPORTANT**: All code files MUST pass PHPStan Level 8 analysis with zero errors. This project maintains the highest code quality standards:
+**IMPORTANT**: All code files MUST pass PHPStan Level 9 analysis with zero errors. This project maintains the highest code quality standards:
 
 - **Type Safety**: All methods must have proper type annotations (`@param`, `@return`)
 - **Strict Types**: All PHP files must declare `strict_types=1`
@@ -802,11 +811,11 @@ This project maintains high code quality through automated tools:
 - **Run**: `composer pint` to format code, `composer pint:test` to check without fixing
 
 ### Larastan (PHPStan for Laravel)
-- **Configuration**: `phpstan.neon` (Level 8 analysis)
+- **Configuration**: `phpstan.neon` (Level 9 analysis)
 - **Purpose**: Static analysis for type safety and bug detection
 - **Features**: Statamic-specific stubs and Laravel integration
 - **Run**: `composer stan` to analyze code
-- **Status**: Zero errors — all files pass Level 8 analysis
+- **Status**: Zero errors — all files pass Level 9 analysis
 
 ### Quality Assurance Workflow
 ```bash

--- a/composer.json
+++ b/composer.json
@@ -30,10 +30,9 @@
     "scripts": {
         "test": "pest",
         "test:coverage": "pest --coverage",
-        "test:parallel": "pest --parallel",
         "pint": "pint",
         "pint:test": "pint --test",
-        "stan": "phpstan analyse",
+        "stan": "phpstan analyse --memory-limit=1G",
         "quality": [
             "@pint",
             "@stan",


### PR DESCRIPTION
## The bug

Every tagged release so far has had to be published by hand, because the release job never finishes:

| Run | Outcome |
|---|---|
| [v2.8.0](https://github.com/cboxdk/statamic-mcp/actions/runs/30488383122) | cancelled at 6h0m15s in `Run tests` |
| [v2.6.1](https://github.com/cboxdk/statamic-mcp/actions/runs/28440361441) | cancelled at 6h0m20s in `Run tests` |
| [v2.7.0](https://github.com/cboxdk/statamic-mcp/actions/runs/28737931533) | failed in `Run tests` — 54 failed, 1005 passed |

## Root cause

`./vendor/bin/pest --parallel` is not safe for this suite, and the shared state is upstream. `Statamic\Testing\AddonTestCase` hardcodes every Stache store directory to `tests/__fixtures__/…`, and `PreventsSavingStacheItemsToDisk` deletes and recreates a single shared `tests/__fixtures__/dev-null`, so ParaTest workers destroy each other's fixtures. Reproduced locally with `--processes=2` — **34 failed, 1026 passed**, against **1060 passed** single-process:

```
mkdir(): File exists
  at vendor/statamic/cms/src/Testing/Concerns/PreventsSavingStacheItemsToDisk.php:29

file_put_contents(.../tests/__fixtures__/dev-null/content/collections/posts-3be1287daf2c05cd.yaml):
  Failed to open stream: No such file or directory

SplFileInfo::getMTime(): stat failed for .../tests/__fixtures__/dev-null/content/collections/dated_df682582.yaml
```

The OAuth cluster of failures has the same shape from our own side: `TestCase::setUp()` blanket-deletes the shared `storage_path('statamic-mcp/oauth')`. When workers collide on the file-store `flock(LOCK_EX)` calls instead of merely racing, the run stops making progress entirely — which is the 6h timeout.

## The fix

Run the same single-process `pest` that already gates pull requests, and put an explicit `timeout-minutes` on every job so a hang surfaces in minutes instead of burning the 6h default.

I did **not** try to make the suite parallel-safe. Isolating per-worker fixtures means overriding the hardcoded paths *and* re-deriving `preventSavingStacheItemsToDisk()`'s relative-path math, for a ~40s saving on an 80s suite. Documented as unsupported instead, and the `composer test:parallel` script that advertised it is removed.

## Two more defects in the same workflow

- **Release notes would have been empty regardless.** The extraction ran `awk '… /\[${{ github.ref_name }}\]/ …'`, i.e. matching `[v2.8.0]` against headings written as `## [2.8.0]`. Now strips the tag's `v` prefix, with a fallback message if the section is missing. Verified against `v2.8.0` (real section), `v2.7.0` (real section) and `v3.0.0` (fallback).
- **The formatting step rewrote code instead of checking it.** `Fix code formatting` ran `pint` in fix mode and discarded the result, so violations could never fail the release. Now `pint --test`.

Plus `--memory-limit=1G` for PHPStan, which otherwise crashes its parallel worker at PHP's default 128M, and a correction to CLAUDE.md, which claimed level 8 where `phpstan.neon` sets level 9.

## Verification

Ran the exact commands the fixed release job will run:

- `DB_CONNECTION=sqlite ./vendor/bin/pest` — **1060 passed** (5437 assertions), 79.86s
- `./vendor/bin/pint --test` — passed
- `composer stan` — no errors

Both workflow files parse as valid YAML, and `composer validate` passes.