### PR TITLE
 feat(format-spec): list valid icon names for icon fields

### DIFF
--- a/src/Mcp/Support/FieldFormatSpec.php
+++ b/src/Mcp/Support/FieldFormatSpec.php
@@ -25,8 +25,13 @@ use Statamic\Fieldtypes\Replicator;
  */
 class FieldFormatSpec
 {
-    /** Upper bound on icon names inlined per field, so a large set cannot dominate a blueprint response. */
-    private const MAX_ICON_NAMES = 500;
+    /**
+     * Icon sets encountered while building specs, so their names can be listed
+     * once per response instead of on every field that uses them.
+     *
+     * @var array<string, list<string>>
+     */
+    private array $iconSets = [];
 
     public function __construct(
         private int $maxDepth = 2,
@@ -379,50 +384,50 @@ class FieldFormatSpec
         $configured = $field->get('set');
         $setName = is_string($configured) && $configured !== '' ? $configured : 'default';
 
-        try {
-            $names = Icons::get($setName)->names()->all();
-        } catch (\Throwable) {
-            return [
-                'wire_format' => 'string',
-                'shape' => 'icon_name',
-                'icon_set' => $setName,
-                'rules' => [
-                    "Icon name from the \"{$setName}\" set, but that set is not registered on this site, so its names cannot be listed.",
-                ],
-            ];
-        }
-
-        /** @var list<string> $names */
-        $names = array_values(array_filter($names, 'is_string'));
-        $total = count($names);
-        $truncated = $total > self::MAX_ICON_NAMES;
-
         $spec = [
             'wire_format' => 'string',
             'shape' => 'icon_name',
             'icon_set' => $setName,
             'rules' => [
                 "Bare icon name from the \"{$setName}\" set — no directory, no \".svg\" suffix, no inline SVG markup.",
-                'Must match one of the listed names exactly. An unlisted name is stored without error and renders nothing.',
+                'Must match one of the names exactly. An unlisted name is stored without error and renders nothing.',
             ],
-            'options' => $truncated ? array_slice($names, 0, self::MAX_ICON_NAMES) : $names,
-            'option_count' => $total,
             'common_mistakes' => [
                 'Sending a filename ("users.svg") or a path ("icons/users.svg") instead of the name ("users").',
                 'Inventing a plausible name — icon sets vary per site, so guessing produces an empty icon rather than an error.',
             ],
         ];
 
-        if ($truncated) {
-            $spec['options_truncated'] = true;
-            $spec['rules'][] = sprintf(
-                'Only the first %d of %d names are listed here.',
-                self::MAX_ICON_NAMES,
-                $total
-            );
+        if (! array_key_exists($setName, $this->iconSets)) {
+            try {
+                /** @var list<string> $names */
+                $names = array_values(array_filter(Icons::get($setName)->names()->all(), 'is_string'));
+                $this->iconSets[$setName] = $names;
+            } catch (\Throwable) {
+                $spec['rules'][] = "The \"{$setName}\" set is not registered on this site, so its names cannot be listed.";
+
+                return $spec;
+            }
         }
 
+        $spec['option_count'] = count($this->iconSets[$setName]);
+        $spec['rules'][] = "Names are listed once per response under icon_sets[\"{$setName}\"].";
+
         return $spec;
+    }
+
+    /**
+     * Icon sets referenced by the fields specced so far, keyed by set name.
+     *
+     * Listing them once keeps a blueprint response proportional to the number
+     * of sets rather than the number of icon fields: a page builder can reach
+     * dozens of icon fields that all point at the same set.
+     *
+     * @return array<string, list<string>>
+     */
+    public function collectedIconSets(): array
+    {
+        return $this->iconSets;
     }
 
     /**

--- a/src/Mcp/Support/FieldFormatSpec.php
+++ b/src/Mcp/Support/FieldFormatSpec.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Cboxdk\StatamicMcp\Mcp\Support;
 
 use Illuminate\Support\Collection;
+use Statamic\Facades\Icon as Icons;
 use Statamic\Fields\Field;
 use Statamic\Fieldtypes\Bard;
 use Statamic\Fieldtypes\Grid;
@@ -24,6 +25,9 @@ use Statamic\Fieldtypes\Replicator;
  */
 class FieldFormatSpec
 {
+    /** Upper bound on icon names inlined per field, so a large set cannot dominate a blueprint response. */
+    private const MAX_ICON_NAMES = 500;
+
     public function __construct(
         private int $maxDepth = 2,
     ) {}
@@ -51,7 +55,8 @@ class FieldFormatSpec
             'grid' => $this->gridSpec($field, $depth),
             'group' => $this->groupSpec($field, $depth),
             'markdown' => $this->markdownSpec(),
-            'text', 'textarea', 'slug', 'code', 'yaml', 'html', 'video', 'color', 'icon' => $this->stringSpec(),
+            'text', 'textarea', 'slug', 'code', 'yaml', 'html', 'video', 'color' => $this->stringSpec(),
+            'icon' => $this->iconSpec($field),
             'integer' => ['wire_format' => 'integer', 'shape' => 'integer'],
             'float' => ['wire_format' => 'number', 'shape' => 'number'],
             'toggle' => ['wire_format' => 'boolean', 'shape' => 'boolean'],
@@ -359,6 +364,65 @@ class FieldFormatSpec
     private function stringSpec(): array
     {
         return ['wire_format' => 'string', 'shape' => 'string'];
+    }
+
+    /**
+     * Icon names live in the set's directory on disk, so they appear nowhere
+     * in the blueprint and an invalid one renders nothing rather than
+     * erroring. Resolution mirrors the fieldtype's own; Icon::get() throws
+     * for an unregistered set, so that degrades to a named string spec.
+     *
+     * @return array<string, mixed>
+     */
+    private function iconSpec(Field $field): array
+    {
+        $configured = $field->get('set');
+        $setName = is_string($configured) && $configured !== '' ? $configured : 'default';
+
+        try {
+            $names = Icons::get($setName)->names()->all();
+        } catch (\Throwable) {
+            return [
+                'wire_format' => 'string',
+                'shape' => 'icon_name',
+                'icon_set' => $setName,
+                'rules' => [
+                    "Icon name from the \"{$setName}\" set, but that set is not registered on this site, so its names cannot be listed.",
+                ],
+            ];
+        }
+
+        /** @var list<string> $names */
+        $names = array_values(array_filter($names, 'is_string'));
+        $total = count($names);
+        $truncated = $total > self::MAX_ICON_NAMES;
+
+        $spec = [
+            'wire_format' => 'string',
+            'shape' => 'icon_name',
+            'icon_set' => $setName,
+            'rules' => [
+                "Bare icon name from the \"{$setName}\" set — no directory, no \".svg\" suffix, no inline SVG markup.",
+                'Must match one of the listed names exactly. An unlisted name is stored without error and renders nothing.',
+            ],
+            'options' => $truncated ? array_slice($names, 0, self::MAX_ICON_NAMES) : $names,
+            'option_count' => $total,
+            'common_mistakes' => [
+                'Sending a filename ("users.svg") or a path ("icons/users.svg") instead of the name ("users").',
+                'Inventing a plausible name — icon sets vary per site, so guessing produces an empty icon rather than an error.',
+            ],
+        ];
+
+        if ($truncated) {
+            $spec['options_truncated'] = true;
+            $spec['rules'][] = sprintf(
+                'Only the first %d of %d names are listed here.',
+                self::MAX_ICON_NAMES,
+                $total
+            );
+        }
+
+        return $spec;
     }
 
     /**

--- a/src/Mcp/Tools/Routers/BlueprintsRouter.php
+++ b/src/Mcp/Tools/Routers/BlueprintsRouter.php
@@ -254,6 +254,10 @@ class BlueprintsRouter extends BaseRouter
                 })->toArray(),
             ];
 
+            if ($formatSpec !== null && ($iconSets = $formatSpec->collectedIconSets()) !== []) {
+                $data['icon_sets'] = $iconSets;
+            }
+
             return ['blueprint' => $data];
         } catch (\Exception $e) {
             return $this->createErrorResponse("Failed to get blueprint: {$e->getMessage()}")->toArray();

--- a/tests/Unit/FieldFormatSpecTest.php
+++ b/tests/Unit/FieldFormatSpecTest.php
@@ -209,13 +209,15 @@ it('lists the icon names a client cannot otherwise discover', function (): void 
     }
     Icon::register('testset', $dir);
 
-    $spec = (new FieldFormatSpec)->for(makeField('icon', ['set' => 'testset']));
+    $formatSpec = new FieldFormatSpec;
+    $spec = $formatSpec->for(makeField('icon', ['set' => 'testset']));
 
     expect($spec['shape'])->toBe('icon_name');
     expect($spec['icon_set'])->toBe('testset');
-    expect($spec['options'])->toEqualCanonicalizing(['users', 'location', 'move']);
     expect($spec['option_count'])->toBe(3);
-    expect($spec)->not->toHaveKey('options_truncated');
+    // Names live once per response, not on every field that uses the set.
+    expect($spec)->not->toHaveKey('options');
+    expect($formatSpec->collectedIconSets()['testset'])->toEqualCanonicalizing(['users', 'location', 'move']);
 
     array_map('unlink', glob("{$dir}/*.svg") ?: []);
     rmdir($dir);
@@ -226,7 +228,7 @@ it('degrades to a plain string spec when the icon set is not registered', functi
 
     expect($spec['shape'])->toBe('icon_name');
     expect($spec['icon_set'])->toBe('nope-not-registered');
-    expect($spec)->not->toHaveKey('options');
+    expect($spec)->not->toHaveKey('option_count');
     expect(implode(' ', $spec['rules']))->toContain('not registered');
 });
 
@@ -237,4 +239,24 @@ it('does not treat an icon field as an opaque string', function (): void {
 
     expect($spec['shape'])->not->toBe('string');
     expect($spec['icon_set'])->toBe('default');
+});
+
+it('collects an icon set once however many fields use it', function (): void {
+    $dir = sys_get_temp_dir() . '/mcp-icons-' . uniqid();
+    mkdir($dir, 0777, true);
+    foreach (['users', 'location'] as $name) {
+        file_put_contents("{$dir}/{$name}.svg", '<svg></svg>');
+    }
+    Icon::register('sharedset', $dir);
+
+    $formatSpec = new FieldFormatSpec;
+    foreach (range(1, 5) as $i) {
+        $formatSpec->for(makeField('icon', ['set' => 'sharedset']));
+    }
+
+    expect($formatSpec->collectedIconSets())->toHaveCount(1);
+    expect($formatSpec->collectedIconSets()['sharedset'])->toHaveCount(2);
+
+    array_map('unlink', glob("{$dir}/*.svg") ?: []);
+    rmdir($dir);
 });

--- a/tests/Unit/FieldFormatSpecTest.php
+++ b/tests/Unit/FieldFormatSpecTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Cboxdk\StatamicMcp\Mcp\Support\FieldFormatSpec;
+use Statamic\Facades\Icon;
 use Statamic\Fields\Field;
 
 function makeField(string $type, array $config = []): Field
@@ -198,4 +199,42 @@ it('returns null for unknown fieldtypes so the response stays small', function (
     $spec = (new FieldFormatSpec)->for(makeField('some_unknown_addon_fieldtype'));
 
     expect($spec)->toBeNull();
+});
+
+it('lists the icon names a client cannot otherwise discover', function (): void {
+    $dir = sys_get_temp_dir() . '/mcp-icons-' . uniqid();
+    mkdir($dir, 0777, true);
+    foreach (['users', 'location', 'move'] as $name) {
+        file_put_contents("{$dir}/{$name}.svg", '<svg></svg>');
+    }
+    Icon::register('testset', $dir);
+
+    $spec = (new FieldFormatSpec)->for(makeField('icon', ['set' => 'testset']));
+
+    expect($spec['shape'])->toBe('icon_name');
+    expect($spec['icon_set'])->toBe('testset');
+    expect($spec['options'])->toEqualCanonicalizing(['users', 'location', 'move']);
+    expect($spec['option_count'])->toBe(3);
+    expect($spec)->not->toHaveKey('options_truncated');
+
+    array_map('unlink', glob("{$dir}/*.svg") ?: []);
+    rmdir($dir);
+});
+
+it('degrades to a plain string spec when the icon set is not registered', function (): void {
+    $spec = (new FieldFormatSpec)->for(makeField('icon', ['set' => 'nope-not-registered']));
+
+    expect($spec['shape'])->toBe('icon_name');
+    expect($spec['icon_set'])->toBe('nope-not-registered');
+    expect($spec)->not->toHaveKey('options');
+    expect(implode(' ', $spec['rules']))->toContain('not registered');
+});
+
+it('does not treat an icon field as an opaque string', function (): void {
+    // Regression guard: icon used to fall through to stringSpec(), which told
+    // a client nothing about which names are valid.
+    $spec = (new FieldFormatSpec)->for(makeField('icon'));
+
+    expect($spec['shape'])->not->toBe('string');
+    expect($spec['icon_set'])->toBe('default');
 });


### PR DESCRIPTION
## Description

An icon field stores a bare name from a registered icon set. The names live in that set's directory on disk, so they appear nowhere in the blueprint — and `icon` fell through to `stringSpec()`, which says only "this is a string".

This reports the resolved set and its names instead, listing each set once per
response rather than on every field that uses it.

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🔧 Tool enhancement
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring

## Related Issue

None — found when a plausible-looking icon name saved without complaint and rendered nothing.

## Testing

- [x] Tests pass (`composer test`)
- [x] Code quality checks pass (`composer quality`)
- [x] Tested manually with Statamic

`tests/Unit/FieldFormatSpecTest.php` — 4 cases: names collected for a registered set, graceful degradation for an unregistered one, a regression guard that `icon` is no longer an opaque string, and a set referenced by many fields
collected once.

Verified against `main`: all 4 fail there, all pass here.
Full gate green — pint, PHPStan level 9, 1110 tests / 5616 assertions.

### Environment
- Statamic: v6.31.0
- Laravel: v13.30.1
- PHP: 8.4.25

## Checklist

- [x] My code follows the project style
- [x] I've added/updated tests if needed
- [x] Tool responses follow the standard format

## Notes

Resolution mirrors the fieldtype's own, `Icon::get(config('set', 'default'))`. That call throws for a set that was never registered, so that case degrades to a named string spec rather than breaking the whole blueprint response.

Names are listed once per response under `blueprint.icon_sets`, with each field carrying `icon_set` and `option_count` and pointing at it. Inlining them per field made the response proportional to the number of icon fields rather than the number of sets: on a page-builder blueprint reaching 24 icon fields that all use one 454-name set, that was ~160KB of duplication against ~19KB now.

An invalid name fails silently in Statamic — it renders nothing rather than erroring — which is why guessing was expensive.