### PR TITLE
fix(format-spec): use the link references ResolveRedirect accepts

### DIFF
--- a/src/Mcp/Support/FieldFormatSpec.php
+++ b/src/Mcp/Support/FieldFormatSpec.php
@@ -79,11 +79,7 @@ class FieldFormatSpec
                 'rules' => ['Time string in HH:MM or HH:MM:SS (24-hour).'],
             ],
             'table' => $this->tableSpec(),
-            'link' => [
-                'wire_format' => 'string',
-                'shape' => 'url_or_entry_reference',
-                'rules' => ['URL string OR statamic://entry/<uuid> reference.'],
-            ],
+            'link' => $this->linkSpec(),
             default => null,
         };
     }
@@ -359,6 +355,41 @@ class FieldFormatSpec
     private function stringSpec(): array
     {
         return ['wire_format' => 'string', 'shape' => 'string'];
+    }
+
+    /**
+     * ResolveRedirect, which backs the link fieldtype, understands
+     * `entry::<id>`, `asset::<container>::<path>`, `@child` and plain URLs.
+     * `statamic://` is Bard link-mark syntax and is stored verbatim here,
+     * rendering a dead link.
+     *
+     * @return array<string, mixed>
+     */
+    private function linkSpec(): array
+    {
+        return [
+            'wire_format' => 'string',
+            'shape' => 'url_or_reference',
+            'rules' => [
+                'Plain URL — absolute ("https://example.com/page") or site-relative ("/contact") — stored and resolved as-is.',
+                'Entry reference: "entry::<entry-id>" (the entry UUID, not its slug or URL).',
+                'Asset reference: "asset::<container>::<path>" (the same id an assets field reports, prefixed with "asset::").',
+                'First-child shorthand: "@child" — only resolves when the field\'s parent is an entry.',
+                'Do NOT use the "statamic://" scheme here. That is Bard link-mark syntax; ResolveRedirect does not understand it and the value is stored verbatim as a broken link.',
+            ],
+            'examples' => [
+                '/contact',
+                'https://example.com/page',
+                'entry::3f2b1a44-0c6e-4c3a-9f1e-8b5d6c7a2e10',
+                'asset::images::brochures/2026.pdf',
+                '@child',
+            ],
+            'common_mistakes' => [
+                'Using "statamic://entry/<uuid>" or "statamic://entry::<uuid>" — neither resolves in a link field.',
+                'Passing an entry slug or URL where an entry id is required.',
+                'Wrapping the value in an array; the link fieldtype stores a plain string.',
+            ],
+        ];
     }
 
     /**

--- a/tests/Unit/FieldFormatSpecTest.php
+++ b/tests/Unit/FieldFormatSpecTest.php
@@ -199,3 +199,27 @@ it('returns null for unknown fieldtypes so the response stays small', function (
 
     expect($spec)->toBeNull();
 });
+
+it('describes the link fieldtype using the references ResolveRedirect actually understands', function (): void {
+    $spec = (new FieldFormatSpec)->for(makeField('link'));
+
+    expect($spec['wire_format'])->toBe('string');
+    expect($spec['shape'])->toBe('url_or_reference');
+
+    $rules = implode(' ', $spec['rules']);
+    expect($rules)->toContain('entry::<entry-id>');
+    expect($rules)->toContain('asset::<container>::<path>');
+    expect($rules)->toContain('@child');
+
+    expect($spec['examples'])->toContain('entry::3f2b1a44-0c6e-4c3a-9f1e-8b5d6c7a2e10');
+    expect($spec['examples'])->toContain('asset::images::brochures/2026.pdf');
+});
+
+it('warns against the statamic:// scheme in a link field', function (): void {
+    $spec = (new FieldFormatSpec)->for(makeField('link'));
+
+    // Bard link marks use statamic://; ResolveRedirect (the link fieldtype)
+    // does not, and stores an unresolvable value verbatim.
+    expect(implode(' ', $spec['rules']))->toContain('statamic://');
+    expect(implode(' ', $spec['common_mistakes']))->toContain('statamic://entry/<uuid>');
+});


### PR DESCRIPTION
## Description

The `link` spec advertises `statamic://entry/<uuid>`. Nothing in Statamic resolves that. `Statamic\Routing\ResolveRedirect`, which backs the link fieldtype, understands exactly four forms: `entry::<id>`, `asset::<container>::<path>`, `@child`, and a plain URL passed through untouched.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔧 Tool enhancement
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring

## Related Issue

None — found following the spec when writing a button link, which stored a value no route ever resolves.

## Testing

- [x] Tests pass (`composer test`)
- [x] Code quality checks pass (`composer quality`)
- [x] Tested manually with Statamic

`tests/Unit/FieldFormatSpecTest.php` — 2 cases. Verified against `main`: both fail there, both pass here. Full suite 1108 tests / 5612 assertions.

### Environment
- Statamic: v6.31.0
- Laravel: v13.30.1
- PHP: 8.4.25

## Checklist

- [x] My code follows the project style
- [x] I've added/updated tests if needed
- [x] Tool responses follow the standard format

## Notes

`statamic://` is Bard syntax — link marks and image nodes go through `Bard\LinkMark` — and even there the form is `statamic://entry::<id>`, not `statamic://entry/<uuid>`.

`Link` defines no `process()`, so a value following the old spec is stored verbatim: no error at write time, and nothing visibly wrong in the CP field until someone clicks the link. The trap is now named in `common_mistakes`.