### PR TITLE
fix(entries): reject keys that are not field handles

### DIFF
--- a/config/statamic/mcp.php
+++ b/config/statamic/mcp.php
@@ -107,6 +107,12 @@ return [
         'max_token_lifetime_days' => env('STATAMIC_MCP_MAX_TOKEN_LIFETIME', 365),
 
         'tool_timeout_seconds' => env('STATAMIC_MCP_TOOL_TIMEOUT', 30),
+
+        // Reject writes carrying keys that are not field handles. Statamic
+        // discards them at the top level and stores them as inert data inside
+        // replicator, grid and bard sets, so an invented handle otherwise
+        // reports success while producing content that does not match.
+        'reject_unknown_fields' => env('STATAMIC_MCP_REJECT_UNKNOWN_FIELDS', true),
     ],
 
     /*

--- a/src/Mcp/Tools/Concerns/SanitizesFieldData.php
+++ b/src/Mcp/Tools/Concerns/SanitizesFieldData.php
@@ -25,6 +25,31 @@ trait SanitizesFieldData
     private static array $entryMetaKeys = ['blueprint', 'fieldset', 'id'];
 
     /**
+     * Record properties a caller may send alongside field data: the routers
+     * consume some before sanitising, and a payload round-tripped from a read
+     * carries the rest.
+     *
+     * @var array<int, string>
+     */
+    private const RECORD_PROPERTY_KEYS = [
+        'id', 'blueprint', 'fieldset', 'slug', 'published', 'date',
+        'created_at', 'created_by', 'updated_at', 'updated_by',
+        'origin', 'locale', 'site', 'collection', 'taxonomy', '_id',
+    ];
+
+    /** Structural keys on a replicator item (see FieldFormatSpec: id, type, enabled). */
+    private const REPLICATOR_ITEM_KEYS = ['id', '_id', 'type', 'enabled'];
+
+    /** Structural keys on a grid row. */
+    private const GRID_ROW_KEYS = ['id', '_id'];
+
+    /** `type` inside a bard set's values names the set, it is not a field handle. */
+    private const BARD_SET_VALUE_KEYS = ['type'];
+
+    /** Cap on handles listed back in an unknown-field error, so the message stays readable. */
+    private const MAX_LISTED_HANDLES = 60;
+
+    /**
      * Sanitize client-provided field data before passing it to validation.
      *
      * This strips reserved entry metadata keys only when they are not real
@@ -71,17 +96,30 @@ trait SanitizesFieldData
     /**
      * @param  Collection<string, Field>  $fields
      * @param  array<string, mixed>  $data
+     * @param  array<int, string>  $structuralKeys
      *
      * @return array<string, mixed>
      */
-    private function sanitizeFieldCollection(Collection $fields, array $data, bool $allowLegacyCoercion, bool $stripEntryMeta): array
-    {
+    private function sanitizeFieldCollection(
+        Collection $fields,
+        array $data,
+        bool $allowLegacyCoercion,
+        bool $stripEntryMeta,
+        string $path = '',
+        array $structuralKeys = self::RECORD_PROPERTY_KEYS
+    ): array {
         if ($stripEntryMeta) {
             foreach (self::$entryMetaKeys as $key) {
                 if (! $fields->has($key)) {
                     unset($data[$key]);
                 }
             }
+        }
+
+        // Stored data being re-validated may carry handles from an older
+        // blueprint; only incoming payloads are held to the current one.
+        if (! $allowLegacyCoercion) {
+            $this->assertKnownHandles($fields, $data, $path, $structuralKeys);
         }
 
         foreach ($fields as $handle => $field) {
@@ -98,6 +136,52 @@ trait SanitizesFieldData
         }
 
         return $data;
+    }
+
+    /**
+     * Reject keys that are not field handles at this level.
+     *
+     * Statamic stays quiet two different ways: Fields::addValues() reads only
+     * handles it knows, discarding stray top-level keys, while Replicator and
+     * Grid processRow() merge the raw row back over the processed one, storing
+     * stray keys inside a set as inert data. Both report success.
+     *
+     * @param  Collection<string, Field>  $fields
+     * @param  array<string, mixed>  $data
+     * @param  array<int, string>  $structuralKeys
+     *
+     * @throws FieldFormatException
+     */
+    private function assertKnownHandles(Collection $fields, array $data, string $path, array $structuralKeys): void
+    {
+        if (! config('statamic.mcp.security.reject_unknown_fields', true)) {
+            return;
+        }
+
+        /** @var array<int, string> $known */
+        $known = $fields->keys()->all();
+
+        $unknown = array_values(array_diff(array_keys($data), $known, $structuralKeys));
+
+        if ($unknown === []) {
+            return;
+        }
+
+        sort($known);
+        $listed = array_slice($known, 0, self::MAX_LISTED_HANDLES);
+        $suffix = count($known) > self::MAX_LISTED_HANDLES
+            ? ' (+' . (count($known) - self::MAX_LISTED_HANDLES) . ' more)'
+            : '';
+
+        throw new FieldFormatException(sprintf(
+            '%s %s not %s in %s. Statamic does not error on unrecognised keys — it discards them at the top level and stores them as inert data inside replicator, grid and bard sets — so this write would have reported success while silently not producing the requested content. Valid handles here: %s%s.',
+            count($unknown) === 1 ? 'Field' : 'Fields',
+            implode(', ', array_map(static fn (string $key): string => "[{$key}]", $unknown)),
+            count($unknown) === 1 ? 'a field' : 'fields',
+            $path === '' ? 'this blueprint' : "[{$path}]",
+            $listed === [] ? '(none)' : implode(', ', $listed),
+            $suffix
+        ));
     }
 
     /**
@@ -193,7 +277,9 @@ trait SanitizesFieldData
                 $fieldtype->fields($setType, (int) $index)->all(),
                 $bardSetValues,
                 $allowLegacyCoercion,
-                false
+                false,
+                $path . '.' . $index . '.attrs.values',
+                self::BARD_SET_VALUE_KEYS
             );
             $node['attrs'] = $bardSetAttrs;
 
@@ -215,7 +301,7 @@ trait SanitizesFieldData
             return [];
         }
 
-        return $this->sanitizeFieldCollection($fieldtype->fields()->all(), $group, $allowLegacyCoercion, false);
+        return $this->sanitizeFieldCollection($fieldtype->fields()->all(), $group, $allowLegacyCoercion, false, $path, []);
     }
 
     /**
@@ -249,7 +335,9 @@ trait SanitizesFieldData
                 $fieldtype->fields((int) $index)->all(),
                 $gridRow,
                 $allowLegacyCoercion,
-                false
+                false,
+                $path . '.' . $index,
+                self::GRID_ROW_KEYS
             );
         }
 
@@ -293,7 +381,9 @@ trait SanitizesFieldData
                 $fieldtype->fields($setType, (int) $index)->all(),
                 $row,
                 $allowLegacyCoercion,
-                false
+                false,
+                $path . '.' . $index,
+                self::REPLICATOR_ITEM_KEYS
             );
         }
 

--- a/tests/Feature/Routers/EntriesUnknownFieldTest.php
+++ b/tests/Feature/Routers/EntriesUnknownFieldTest.php
@@ -1,0 +1,235 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cboxdk\StatamicMcp\Tests\Feature\Routers;
+
+use Cboxdk\StatamicMcp\Mcp\Tools\Routers\EntriesRouter;
+use Cboxdk\StatamicMcp\Tests\TestCase;
+use Statamic\Facades\Blueprint;
+use Statamic\Facades\Collection;
+use Statamic\Facades\Entry;
+use Statamic\Facades\Stache;
+
+/**
+ * A key that is not a field handle must fail loudly.
+ *
+ * Statamic swallows them in two different ways, both invisible to the caller:
+ * Fields::addValues() only reads handles it knows, so a stray key at the top
+ * level is discarded, while Replicator::processRow() and Grid::processRow()
+ * merge the raw row back over the processed one, so a stray key inside a set
+ * is written to the content file as inert data. Either way the write reports
+ * success and the content does not match the request — undiagnosable for a
+ * client that cannot read the blueprint from the repository.
+ */
+class EntriesUnknownFieldTest extends TestCase
+{
+    private EntriesRouter $router;
+
+    private string $collectionHandle;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->router = new EntriesRouter;
+        $this->collectionHandle = 'pages-' . bin2hex(random_bytes(4));
+        Collection::make($this->collectionHandle)->title('Pages')->save();
+
+        Blueprint::make('pages')->setNamespace("collections.{$this->collectionHandle}")->setContents([
+            'fields' => [
+                ['handle' => 'title', 'field' => ['type' => 'text']],
+                ['handle' => 'intro', 'field' => ['type' => 'textarea']],
+                ['handle' => 'rows', 'field' => [
+                    'type' => 'grid',
+                    'fields' => [
+                        ['handle' => 'caption', 'field' => ['type' => 'text']],
+                    ],
+                ]],
+                ['handle' => 'page_builder', 'field' => [
+                    'type' => 'replicator',
+                    'sets' => [
+                        'main' => [
+                            'sets' => [
+                                'content_section' => [
+                                    'fields' => [
+                                        ['handle' => 'body', 'field' => ['type' => 'textarea']],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ]],
+                ['handle' => 'story', 'field' => [
+                    'type' => 'bard',
+                    'sets' => [
+                        'main' => [
+                            'sets' => [
+                                'quote' => [
+                                    'fields' => [
+                                        ['handle' => 'cite', 'field' => ['type' => 'text']],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ]],
+            ],
+        ])->save();
+
+        Stache::refresh();
+    }
+
+    private function makeEntry(string $id): void
+    {
+        Entry::make()
+            ->id($id)
+            ->collection($this->collectionHandle)
+            ->slug($id)
+            ->data(['title' => 'Home'])
+            ->save();
+    }
+
+    public function test_rejects_an_unknown_top_level_handle(): void
+    {
+        $result = $this->router->execute([
+            'action' => 'create',
+            'collection' => $this->collectionHandle,
+            'slug' => 'about',
+            'data' => ['title' => 'About', 'subtitle' => 'silently dropped today'],
+        ]);
+
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('[subtitle]', implode(' ', $result['errors']));
+        $this->assertNull(Entry::query()->where('slug', 'about')->first());
+    }
+
+    public function test_rejects_an_unknown_handle_inside_a_replicator_set(): void
+    {
+        $this->makeEntry('home');
+
+        // The real-world case: a `cards` array sent to a set that has no such
+        // field. Statamic stores it as junk that no template ever reads.
+        $result = $this->router->execute([
+            'action' => 'update',
+            'collection' => $this->collectionHandle,
+            'id' => 'home',
+            'data' => [
+                'page_builder' => [[
+                    'id' => 'set-1',
+                    'type' => 'content_section',
+                    'enabled' => true,
+                    'body' => 'Kept',
+                    'cards' => [['id' => 'c1', 'label' => 'Never rendered']],
+                ]],
+            ],
+        ]);
+
+        $this->assertFalse($result['success']);
+        $errors = implode(' ', $result['errors']);
+        $this->assertStringContainsString('[cards]', $errors);
+        $this->assertStringContainsString('page_builder.0', $errors);
+        // The valid handles are named so the client can correct itself.
+        $this->assertStringContainsString('body', $errors);
+
+        $this->assertNull(Entry::find('home')->get('page_builder'));
+    }
+
+    public function test_rejects_an_unknown_handle_inside_a_grid_row(): void
+    {
+        $this->makeEntry('grid');
+
+        $result = $this->router->execute([
+            'action' => 'update',
+            'collection' => $this->collectionHandle,
+            'id' => 'grid',
+            'data' => ['rows' => [['id' => 'r1', 'caption' => 'ok', 'headline' => 'not a field']]],
+        ]);
+
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('[headline]', implode(' ', $result['errors']));
+    }
+
+    public function test_rejects_an_unknown_handle_inside_a_bard_set(): void
+    {
+        $this->makeEntry('bard');
+
+        $result = $this->router->execute([
+            'action' => 'update',
+            'collection' => $this->collectionHandle,
+            'id' => 'bard',
+            'data' => [
+                'story' => [[
+                    'type' => 'set',
+                    'attrs' => [
+                        'id' => 'node-1',
+                        'values' => ['type' => 'quote', 'cite' => 'Ada', 'attribution' => 'not a field'],
+                    ],
+                ]],
+            ],
+        ]);
+
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('[attribution]', implode(' ', $result['errors']));
+    }
+
+    public function test_accepts_structural_keys_on_sets_and_rows(): void
+    {
+        $this->makeEntry('structural');
+
+        $result = $this->router->execute([
+            'action' => 'update',
+            'collection' => $this->collectionHandle,
+            'id' => 'structural',
+            'data' => [
+                'page_builder' => [['id' => 's1', 'type' => 'content_section', 'enabled' => true, 'body' => 'ok']],
+                'rows' => [['id' => 'r1', 'caption' => 'ok']],
+                'story' => [[
+                    'type' => 'set',
+                    'attrs' => ['id' => 'n1', 'values' => ['type' => 'quote', 'cite' => 'Ada']],
+                ]],
+            ],
+        ]);
+
+        $this->assertTrue($result['success'], json_encode($result['errors'] ?? []));
+    }
+
+    public function test_accepts_record_properties_a_read_hands_back(): void
+    {
+        $this->makeEntry('roundtrip');
+
+        // get() emits these alongside field data; a naive round-trip sends the
+        // whole object back and must not be rejected for it.
+        $result = $this->router->execute([
+            'action' => 'update',
+            'collection' => $this->collectionHandle,
+            'id' => 'roundtrip',
+            'data' => [
+                'id' => 'roundtrip',
+                'blueprint' => 'pages',
+                'slug' => 'roundtrip',
+                'updated_at' => 1788862250,
+                'updated_by' => null,
+                'title' => 'Round trip',
+            ],
+        ]);
+
+        $this->assertTrue($result['success'], json_encode($result['errors'] ?? []));
+        $this->assertSame('Round trip', Entry::find('roundtrip')->get('title'));
+    }
+
+    public function test_the_check_can_be_disabled(): void
+    {
+        config(['statamic.mcp.security.reject_unknown_fields' => false]);
+        $this->makeEntry('lenient');
+
+        $result = $this->router->execute([
+            'action' => 'update',
+            'collection' => $this->collectionHandle,
+            'id' => 'lenient',
+            'data' => ['title' => 'Lenient', 'subtitle' => 'tolerated'],
+        ]);
+
+        $this->assertTrue($result['success'], json_encode($result['errors'] ?? []));
+    }
+}


### PR DESCRIPTION
## Description

A key that is not a field handle is accepted silently today. Statamic stays quiet in two different ways: `Fields::addValues()` reads only handles it knows, so a stray key at the top level is discarded, while `Replicator::processRow()` and `Grid::processRow()` do `array_merge($row, $fields)`, so a stray key inside a set or row is merged back and written to the content file as inert data. Both report success while the content does not match what was asked for.

This rejects them instead, naming the path, the offending handles and the valid handles at that level.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔧 Tool enhancement
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring

## Related Issue

None — found writing a page-builder (replicator) entry where a section carried a handle that does not exist on that set. `create` returned success and the section rendered without it; nothing in the response pointed at the key.

## Testing

- [x] Tests pass (`composer test`)
- [x] Code quality checks pass (`composer quality`)
- [x] Tested manually with Statamic

`tests/Feature/Routers/EntriesUnknownFieldTest.php` — 7 cases: unknown handle at the top level, in a replicator set, in a grid row and in a bard set, plus guards that structural keys, round-tripped record properties and the config switch still work.

Also exercised against a real multi-set page-builder blueprint: an invented handle inside a set is rejected with the path and the valid handles, nothing is written, and a valid payload still saves.

Verified against `main`: 4 of the 7 fail there, all pass here.
Full gate green — pint, PHPStan level 9, 1113 tests / 5619 assertions.

### Environment
- Statamic: v6.31.0
- Laravel: v13.30.1
- PHP: 8.4.25

## Checklist

- [x] My code follows the project style
- [x] I've added/updated tests if needed
- [x] Tool responses follow the standard format

## Notes

The check runs on incoming payloads only. Stored data being re-validated (`$allowLegacyCoercion`) may carry handles from an older blueprint, and rejecting those would block every update to an entry that predates a field rename.

Record properties a read emits (`id`, `slug`, `updated_at`, …) and the structural keys of sets, rows and bard nodes stay allowed, so a `get` → `update` round-trip is unaffected. All 1106 existing tests pass unchanged with the check on.

Opt out with `statamic.mcp.security.reject_unknown_fields`.