### PR TITLE
feat(fieldtypes): let addons describe fieldtypes the package does not know

### DIFF
--- a/src/Mcp/Support/FieldFormatSpec.php
+++ b/src/Mcp/Support/FieldFormatSpec.php
@@ -84,7 +84,7 @@ class FieldFormatSpec
                 'shape' => 'url_or_entry_reference',
                 'rules' => ['URL string OR statamic://entry/<uuid> reference.'],
             ],
-            default => null,
+            default => FieldtypeExtensions::resolveSpec($field),
         };
     }
 

--- a/src/Mcp/Support/FieldtypeExtensions.php
+++ b/src/Mcp/Support/FieldtypeExtensions.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cboxdk\StatamicMcp\Mcp\Support;
+
+use Statamic\Fields\Field;
+
+/**
+ * Registry letting a site or addon teach the MCP about a fieldtype it does not
+ * ship support for.
+ *
+ * Statamic's fieldtype set is open, but this package's is closed: an unknown
+ * fieldtype gets no wire-format guidance and no input coercion, so a client
+ * guesses at the shape and the guess reaches a process() written for
+ * Control-Panel input.
+ *
+ * `aerni/advanced-seo` is the worked example. Its `seo` fieldtype stores
+ * ['source' => ..., 'value' => ...]; a plain string dies on $data['source']
+ * with "Cannot access offset of type string on string".
+ *
+ * Register from a service provider's boot(). Registrations are keyed by
+ * fieldtype handle, so a later one replaces an earlier one.
+ */
+class FieldtypeExtensions
+{
+    /**
+     * Wire-format resolvers, keyed by fieldtype handle.
+     *
+     * @var array<string, callable(Field): (array<string, mixed>|null)>
+     */
+    private static array $specs = [];
+
+    /**
+     * Value sanitizers, keyed by fieldtype handle.
+     *
+     * @var array<string, callable(mixed, Field, string): mixed>
+     */
+    private static array $sanitizers = [];
+
+    /**
+     * Describe the wire format of a fieldtype the MCP does not know. The
+     * resolver returns the structure the built-in specs use, or null.
+     *
+     * @param  callable(Field): (array<string, mixed>|null)  $resolver
+     */
+    public static function spec(string $fieldtype, callable $resolver): void
+    {
+        self::$specs[$fieldtype] = $resolver;
+    }
+
+    /**
+     * Coerce or reject an incoming value, before validation and the
+     * fieldtype's own process(). Throw a FieldFormatException to reject.
+     *
+     * @param  callable(mixed, Field, string): mixed  $sanitizer
+     */
+    public static function sanitizer(string $fieldtype, callable $sanitizer): void
+    {
+        self::$sanitizers[$fieldtype] = $sanitizer;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public static function resolveSpec(Field $field): ?array
+    {
+        $resolver = self::$specs[$field->type()] ?? null;
+
+        return $resolver === null ? null : $resolver($field);
+    }
+
+    public static function hasSanitizer(Field $field): bool
+    {
+        return isset(self::$sanitizers[$field->type()]);
+    }
+
+    public static function applySanitizer(Field $field, mixed $value, string $path): mixed
+    {
+        $sanitizer = self::$sanitizers[$field->type()] ?? null;
+
+        return $sanitizer === null ? $value : $sanitizer($value, $field, $path);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public static function registered(): array
+    {
+        return array_values(array_unique(array_merge(
+            array_keys(self::$specs),
+            array_keys(self::$sanitizers)
+        )));
+    }
+
+    /** Drop every registration. Intended for tests. */
+    public static function flush(): void
+    {
+        self::$specs = [];
+        self::$sanitizers = [];
+    }
+}

--- a/src/Mcp/Tools/Concerns/SanitizesFieldData.php
+++ b/src/Mcp/Tools/Concerns/SanitizesFieldData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Cboxdk\StatamicMcp\Mcp\Tools\Concerns;
 
 use Cboxdk\StatamicMcp\Mcp\Exceptions\FieldFormatException;
+use Cboxdk\StatamicMcp\Mcp\Support\FieldtypeExtensions;
 use Illuminate\Support\Collection;
 use Statamic\Fields\Blueprint;
 use Statamic\Fields\Field;
@@ -121,7 +122,8 @@ trait SanitizesFieldData
             'table' => $this->sanitizeTableValue($value, $allowLegacyCoercion, $path),
             'assets' => $this->normalizeAssetFieldValue($field, $value),
             'terms', 'entries', 'users', 'checkboxes' => $this->sanitizeRelationshipValue($value),
-            default => $value,
+            // Untouched unless a sanitizer is registered for the fieldtype.
+            default => FieldtypeExtensions::applySanitizer($field, $value, $path),
         };
     }
 

--- a/tests/Feature/Routers/FieldtypeExtensionsWiringTest.php
+++ b/tests/Feature/Routers/FieldtypeExtensionsWiringTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cboxdk\StatamicMcp\Tests\Feature\Routers;
+
+use Cboxdk\StatamicMcp\Mcp\Exceptions\FieldFormatException;
+use Cboxdk\StatamicMcp\Mcp\Support\FieldtypeExtensions;
+use Cboxdk\StatamicMcp\Mcp\Tools\Routers\BlueprintsRouter;
+use Cboxdk\StatamicMcp\Mcp\Tools\Routers\EntriesRouter;
+use Cboxdk\StatamicMcp\Tests\TestCase;
+use Statamic\Facades\Blueprint;
+use Statamic\Facades\Collection;
+use Statamic\Facades\Entry;
+use Statamic\Facades\Stache;
+use Statamic\Fields\Field;
+
+/**
+ * Proves the registry is actually reached by the two paths that matter: the
+ * blueprint's wire-format spec, and the entry write pipeline.
+ *
+ * `list` stands in for any fieldtype the package has no arm for — the same
+ * position `seo` from aerni/advanced-seo occupies on a real site.
+ */
+class FieldtypeExtensionsWiringTest extends TestCase
+{
+    private string $collectionHandle;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        FieldtypeExtensions::flush();
+
+        $this->collectionHandle = 'pages-' . bin2hex(random_bytes(4));
+        Collection::make($this->collectionHandle)->title('Pages')->save();
+
+        Blueprint::make('pages')->setNamespace("collections.{$this->collectionHandle}")->setContents([
+            'fields' => [
+                ['handle' => 'title', 'field' => ['type' => 'text']],
+                ['handle' => 'keywords', 'field' => ['type' => 'list']],
+            ],
+        ])->save();
+
+        Stache::refresh();
+    }
+
+    protected function tearDown(): void
+    {
+        FieldtypeExtensions::flush();
+
+        parent::tearDown();
+    }
+
+    public function test_blueprint_get_serves_a_registered_spec(): void
+    {
+        $before = $this->fieldSpec();
+        $this->assertArrayNotHasKey('_format_spec', $before);
+
+        FieldtypeExtensions::spec('list', fn (Field $field): array => [
+            'wire_format' => 'array',
+            'shape' => 'string_list',
+            'rules' => ['Array of plain strings.'],
+        ]);
+
+        $after = $this->fieldSpec();
+        $this->assertSame('string_list', $after['_format_spec']['shape']);
+    }
+
+    public function test_a_registered_sanitizer_runs_on_write(): void
+    {
+        FieldtypeExtensions::sanitizer('list', function (mixed $value): mixed {
+            return is_array($value) ? array_map('strtoupper', $value) : $value;
+        });
+
+        $result = (new EntriesRouter)->execute([
+            'action' => 'create',
+            'collection' => $this->collectionHandle,
+            'slug' => 'coerced',
+            'data' => ['title' => 'Coerced', 'keywords' => ['alpha', 'beta']],
+        ]);
+
+        $this->assertTrue($result['success'], json_encode($result['errors'] ?? []));
+
+        $entry = Entry::query()->where('slug', 'coerced')->first();
+        $this->assertSame(['ALPHA', 'BETA'], $entry->get('keywords'));
+    }
+
+    public function test_a_registered_sanitizer_can_reject_a_bad_shape(): void
+    {
+        FieldtypeExtensions::sanitizer('list', function (mixed $value, Field $field, string $path): mixed {
+            if (! is_array($value)) {
+                throw new FieldFormatException("Field [{$path}] expects an array of strings.");
+            }
+
+            return $value;
+        });
+
+        $result = (new EntriesRouter)->execute([
+            'action' => 'create',
+            'collection' => $this->collectionHandle,
+            'slug' => 'rejected',
+            'data' => ['title' => 'Rejected', 'keywords' => 'not-an-array'],
+        ]);
+
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('[keywords] expects an array', implode(' ', $result['errors']));
+        $this->assertNull(Entry::query()->where('slug', 'rejected')->first());
+    }
+
+    public function test_values_pass_through_untouched_without_a_registration(): void
+    {
+        $result = (new EntriesRouter)->execute([
+            'action' => 'create',
+            'collection' => $this->collectionHandle,
+            'slug' => 'untouched',
+            'data' => ['title' => 'Untouched', 'keywords' => ['alpha']],
+        ]);
+
+        $this->assertTrue($result['success'], json_encode($result['errors'] ?? []));
+        $this->assertSame(['alpha'], Entry::query()->where('slug', 'untouched')->first()->get('keywords'));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function fieldSpec(): array
+    {
+        $result = (new BlueprintsRouter)->execute([
+            'action' => 'get',
+            'namespace' => 'collections',
+            'collection_handle' => $this->collectionHandle,
+            'handle' => 'pages',
+            'include_format_spec' => true,
+        ]);
+
+        foreach ($result['data']['blueprint']['fields'] ?? [] as $field) {
+            if (($field['handle'] ?? null) === 'keywords') {
+                return $field;
+            }
+        }
+
+        $this->fail('keywords field missing from blueprint response: ' . json_encode($result));
+    }
+}

--- a/tests/Unit/FieldtypeExtensionsTest.php
+++ b/tests/Unit/FieldtypeExtensionsTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+use Cboxdk\StatamicMcp\Mcp\Exceptions\FieldFormatException;
+use Cboxdk\StatamicMcp\Mcp\Support\FieldFormatSpec;
+use Cboxdk\StatamicMcp\Mcp\Support\FieldtypeExtensions;
+use Statamic\Fields\Field;
+
+/**
+ * The `seo` fieldtype from aerni/advanced-seo is the worked example: it stores
+ * ['source' => ..., 'value' => ...] and dies on a plain string inside its own
+ * process(), with a TypeError that names neither the field nor the shape.
+ */
+function seoField(string $handle = 'seo_title'): Field
+{
+    return new Field($handle, ['type' => 'seo']);
+}
+
+beforeEach(fn () => FieldtypeExtensions::flush());
+afterEach(fn () => FieldtypeExtensions::flush());
+
+it('returns no spec for an unknown fieldtype by default', function (): void {
+    expect((new FieldFormatSpec)->for(seoField()))->toBeNull();
+});
+
+it('serves a registered spec for a fieldtype the package does not know', function (): void {
+    FieldtypeExtensions::spec('seo', fn (Field $field): array => [
+        'wire_format' => 'object',
+        'shape' => 'seo_value',
+        'rules' => ['Object with "source" ("custom" or "default") and "value".'],
+        'example' => ['source' => 'custom', 'value' => 'Page title'],
+    ]);
+
+    $spec = (new FieldFormatSpec)->for(seoField());
+
+    expect($spec['shape'])->toBe('seo_value');
+    expect($spec['example'])->toBe(['source' => 'custom', 'value' => 'Page title']);
+});
+
+it('passes the field to the resolver so a spec can vary by config', function (): void {
+    FieldtypeExtensions::spec('seo', fn (Field $field): array => ['handle' => $field->handle()]);
+
+    expect((new FieldFormatSpec)->for(seoField('seo_description'))['handle'])
+        ->toBe('seo_description');
+});
+
+it('leaves values untouched when no sanitizer is registered', function (): void {
+    expect(FieldtypeExtensions::applySanitizer(seoField(), 'plain string', 'seo_title'))
+        ->toBe('plain string');
+});
+
+it('applies a registered sanitizer to coerce a value', function (): void {
+    FieldtypeExtensions::sanitizer('seo', fn (mixed $value): mixed => is_string($value)
+        ? ['source' => 'custom', 'value' => $value]
+        : $value);
+
+    expect(FieldtypeExtensions::applySanitizer(seoField(), 'Page title', 'seo_title'))
+        ->toBe(['source' => 'custom', 'value' => 'Page title']);
+});
+
+it('lets a sanitizer reject a value with a path-bearing error', function (): void {
+    FieldtypeExtensions::sanitizer('seo', function (mixed $value, Field $field, string $path): mixed {
+        if (! is_array($value)) {
+            throw new FieldFormatException("Field [{$path}] expects an object with source and value.");
+        }
+
+        return $value;
+    });
+
+    expect(fn () => FieldtypeExtensions::applySanitizer(seoField(), 'oops', 'seo_title'))
+        ->toThrow(FieldFormatException::class, 'Field [seo_title] expects an object');
+});
+
+it('lets a later registration replace an earlier one', function (): void {
+    FieldtypeExtensions::spec('seo', fn (): array => ['shape' => 'first']);
+    FieldtypeExtensions::spec('seo', fn (): array => ['shape' => 'second']);
+
+    expect((new FieldFormatSpec)->for(seoField())['shape'])->toBe('second');
+});
+
+it('reports which fieldtypes have been extended', function (): void {
+    FieldtypeExtensions::spec('seo', fn (): array => []);
+    FieldtypeExtensions::sanitizer('seo', fn (mixed $v): mixed => $v);
+    FieldtypeExtensions::sanitizer('bard_texstyle', fn (mixed $v): mixed => $v);
+
+    expect(FieldtypeExtensions::registered())->toEqualCanonicalizing(['seo', 'bard_texstyle']);
+});


### PR DESCRIPTION
## Description

Statamic's fieldtype set is open, but this package's is closed: `FieldFormatSpec::for()` ends in `default => null` and the sanitizer's match in `default => $value`. A fieldtype from an addon gets no wire-format guidance and no input coercion, so a caller guesses at the shape and the guess reaches a `process()` written for Control-Panel input.

Adds `FieldtypeExtensions`, a registry consulted from the `default` arm of both matches, so a site or addon can describe its own fieldtypes.

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🔧 Tool enhancement
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring

## Related Issue

None — found writing an entry with a structured [Advanced SEO](https://github.com/aerni/statamic-advanced-seo) fieldtype. It stores `['source' => ..., 'value' => ...]`; a plain string dies inside its own `process()` on `$data['source']` with "Cannot access offset of type string on string", which names neither the field nor the shape. `statamic-blueprints` had nothing to say about the field either, so the correct shape could not be discovered from the tools.

## Testing

- [x] Tests pass (`composer test`)
- [x] Code quality checks pass (`composer quality`)
- [x] Tested manually with Statamic

`tests/Unit/FieldtypeExtensionsTest.php` — 8 cases for the registry.
`tests/Feature/Routers/FieldtypeExtensionsWiringTest.php` — 4 cases proving both
seams are reached, through `statamic-blueprints get` and an entry write.

Also exercised against the real SEO fieldtype on a live install: the plain string reproduces the TypeError before registering, and after registering a spec and sanitizer the blueprint describes the field and the same payload writes the value the fieldtype expects.

The registry does not exist on `main`, so these are new coverage rather than a before/after. Full gate green — pint, PHPStan level 9, 1118 tests / 5622 assertions.

### Environment
- Statamic: v6.31.0
- Laravel: v13.30.1
- PHP: 8.4.25

## Checklist

- [x] My code follows the project style
- [x] I've added/updated tests if needed
- [x] Tool responses follow the standard format

## Notes

Two registration points, keyed by fieldtype handle:

- `spec($fieldtype, $resolver)` — wire format for `statamic-blueprints`
- `sanitizer($fieldtype, $callback)` — coercion on write, or a
  `FieldFormatException` to reject with a path

A later registration replaces an earlier one, so a site can override an addon's.

Neither seam was reachable before: `BlueprintsRouter` constructs `FieldFormatSpec` directly and the sanitizer is a trait with a hardcoded match, so this could only be fixed by forking. Sites that register nothing see no change — no spec is still no spec, and values still pass through untouched.