### PR TITLE
feat(entries): merge replicator items by id with merge_sets

### DIFF
--- a/src/Mcp/Tools/Routers/EntriesRouter.php
+++ b/src/Mcp/Tools/Routers/EntriesRouter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Cboxdk\StatamicMcp\Mcp\Tools\Routers;
 
+use Cboxdk\StatamicMcp\Mcp\Exceptions\FieldFormatException;
 use Cboxdk\StatamicMcp\Mcp\Tools\BaseRouter;
 use Cboxdk\StatamicMcp\Mcp\Tools\Concerns\ClearsCaches;
 use Cboxdk\StatamicMcp\Mcp\Tools\Concerns\HandlesRevisions;
@@ -11,13 +12,17 @@ use Cboxdk\StatamicMcp\Mcp\Tools\Concerns\NormalizesDateFields;
 use Cboxdk\StatamicMcp\Mcp\Tools\Concerns\SanitizesFieldData;
 use Illuminate\Contracts\JsonSchema\JsonSchema as JsonSchemaContract;
 use Illuminate\JsonSchema\JsonSchema;
+use Illuminate\Support\Collection as SupportCollection;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\ValidationException;
 use Laravel\Mcp\Server\Attributes\Description;
 use Laravel\Mcp\Server\Attributes\Name;
 use Laravel\Mcp\Server\Attributes\Title;
+use Statamic\Contracts\Entries\Entry as EntryContract;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
+use Statamic\Fields\Blueprint;
+use Statamic\Fields\Field;
 use Statamic\Fields\Validator as FieldsValidator;
 use Statamic\Rules\UniqueEntryValue;
 use Statamic\Support\Str;
@@ -46,7 +51,7 @@ class EntriesRouter extends BaseRouter
                     . 'list (collection; optional: limit, offset, filters, include_unpublished), '
                     . 'get (collection, id; optional: version), '
                     . 'create (collection, data — use statamic-blueprints get to see field structure first), '
-                    . 'update (collection, id, data; optional: revision_message), '
+                    . 'update (collection, id, data; optional: revision_message, merge_sets), '
                     . 'delete (collection, id), '
                     . 'publish (collection, id; optional: revision_message), '
                     . 'unpublish (collection, id; optional: revision_message), '
@@ -93,6 +98,17 @@ class EntriesRouter extends BaseRouter
             'version' => JsonSchema::string()
                 ->description('Which version of the entry to return for get action. "published" (default): live published data, "working_copy": current working copy data, "latest": working copy if exists else published')
                 ->enum(['published', 'working_copy', 'latest']),
+
+            'merge_sets' => JsonSchema::boolean()
+                ->description(
+                    'Update action only. When true, a replicator field in "data" is merged into the stored '
+                    . 'array by item id instead of replacing it: items whose id already exists are replaced in '
+                    . 'place, new ids are appended, and stored items you did not send are left untouched. Use it '
+                    . 'to change one section of a page builder without resending the whole array. Every item sent '
+                    . 'must carry an "id". Removing or reordering items still requires sending the full array with '
+                    . 'merge_sets off. Applies to top-level replicator fields only — not bard, whose nodes are not '
+                    . 'all addressable by id.'
+                ),
 
             'revision_message' => JsonSchema::string()
                 ->description('Optional message to attach to a revision (for update, publish, unpublish, publish_working_copy actions)'),
@@ -505,6 +521,85 @@ class EntriesRouter extends BaseRouter
     }
 
     /**
+     * Merge replicator items into the entry's stored array, addressed by the
+     * `id` every item already carries: an existing id is replaced in place, a
+     * new one appended, and unsent items left alone.
+     *
+     * Top-level replicators only, and replace-or-append only. Removing and
+     * reordering stay with a full-array write, where the intent is
+     * unambiguous. Bard is excluded because most of its nodes carry no id.
+     *
+     * @param  array<string, mixed>  $data
+     *
+     * @return array<string, mixed>
+     *
+     * @throws FieldFormatException
+     */
+    private function mergeReplicatorSets(Blueprint $blueprint, EntryContract $entry, array $data): array
+    {
+        /** @var SupportCollection<string, Field> $fields */
+        $fields = $blueprint->fields()->all();
+
+        foreach ($data as $handle => $incoming) {
+            $field = $fields->get($handle);
+
+            if (! $field instanceof Field || $field->type() !== 'replicator') {
+                continue;
+            }
+
+            if (! is_array($incoming)) {
+                throw new FieldFormatException("Field [{$handle}] must be an array of replicator items to merge.");
+            }
+
+            $stored = $entry->get($handle);
+            $stored = is_array($stored) ? array_values($stored) : [];
+
+            $positions = [];
+            foreach ($stored as $index => $item) {
+                if (is_array($item) && is_string($item['id'] ?? null)) {
+                    $positions[$item['id']] = $index;
+                }
+            }
+
+            $merged = $stored;
+            $seen = [];
+
+            foreach (array_values($incoming) as $index => $item) {
+                if (! is_array($item)) {
+                    throw new FieldFormatException("Field [{$handle}.{$index}] must be a replicator item object when merge_sets is on.");
+                }
+
+                $id = $item['id'] ?? null;
+
+                if (! is_string($id) || $id === '') {
+                    throw new FieldFormatException(
+                        "Field [{$handle}.{$index}] needs an \"id\" when merge_sets is on — that is how the item to replace is found. "
+                        . 'Read the entry to get the ids, or turn merge_sets off to replace the whole array.'
+                    );
+                }
+
+                if (isset($seen[$id])) {
+                    throw new FieldFormatException("Field [{$handle}] sends id \"{$id}\" more than once; ids must be unique within the array.");
+                }
+
+                $seen[$id] = true;
+
+                if (isset($positions[$id])) {
+                    $merged[$positions[$id]] = $item;
+
+                    continue;
+                }
+
+                $merged[] = $item;
+            }
+
+            $data[$handle] = array_values($merged);
+        }
+
+        return $data;
+    }
+
+    /**
      * Update an existing entry.
      *
      * @param  array<string, mixed>  $arguments
@@ -596,6 +691,14 @@ class EntriesRouter extends BaseRouter
             }
 
             if (! empty($data)) {
+                if (($arguments['merge_sets'] ?? false) === true) {
+                    try {
+                        $data = $this->mergeReplicatorSets($blueprint, $entry, $data);
+                    } catch (FieldFormatException $e) {
+                        return $this->createErrorResponse($e->getMessage())->toArray();
+                    }
+                }
+
                 // Strip entry-level metadata and coerce values to expected types
                 $data = $this->sanitizeIncomingFieldData($blueprint, $data);
 

--- a/tests/Feature/Routers/EntriesMergeSetsTest.php
+++ b/tests/Feature/Routers/EntriesMergeSetsTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cboxdk\StatamicMcp\Tests\Feature\Routers;
+
+use Cboxdk\StatamicMcp\Mcp\Tools\Routers\EntriesRouter;
+use Cboxdk\StatamicMcp\Tests\TestCase;
+use Statamic\Facades\Blueprint;
+use Statamic\Facades\Collection;
+use Statamic\Facades\Entry;
+use Statamic\Facades\Stache;
+
+/**
+ * merge_sets lets a caller change one section of a page builder without
+ * reading and resending every other section.
+ */
+class EntriesMergeSetsTest extends TestCase
+{
+    private EntriesRouter $router;
+
+    private string $collectionHandle;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->router = new EntriesRouter;
+        $this->collectionHandle = 'pages-' . bin2hex(random_bytes(4));
+        Collection::make($this->collectionHandle)->title('Pages')->save();
+
+        Blueprint::make('pages')->setNamespace("collections.{$this->collectionHandle}")->setContents([
+            'fields' => [
+                ['handle' => 'title', 'field' => ['type' => 'text']],
+                ['handle' => 'page_builder', 'field' => [
+                    'type' => 'replicator',
+                    'sets' => [
+                        'main' => [
+                            'sets' => [
+                                'hero' => ['fields' => [['handle' => 'body', 'field' => ['type' => 'textarea']]]],
+                                'cta' => ['fields' => [['handle' => 'body', 'field' => ['type' => 'textarea']]]],
+                            ],
+                        ],
+                    ],
+                ]],
+            ],
+        ])->save();
+
+        Stache::refresh();
+    }
+
+    private function makeEntry(): void
+    {
+        Entry::make()
+            ->id('home')
+            ->collection($this->collectionHandle)
+            ->slug('home')
+            ->data([
+                'title' => 'Home',
+                'page_builder' => [
+                    ['id' => 's1', 'type' => 'hero', 'enabled' => true, 'body' => 'First'],
+                    ['id' => 's2', 'type' => 'cta', 'enabled' => true, 'body' => 'Second'],
+                    ['id' => 's3', 'type' => 'cta', 'enabled' => true, 'body' => 'Third'],
+                ],
+            ])
+            ->save();
+    }
+
+    public function test_replaces_one_set_in_place_and_leaves_the_rest_alone(): void
+    {
+        $this->makeEntry();
+
+        $result = $this->router->execute([
+            'action' => 'update',
+            'collection' => $this->collectionHandle,
+            'id' => 'home',
+            'merge_sets' => true,
+            'data' => [
+                'page_builder' => [
+                    ['id' => 's2', 'type' => 'cta', 'enabled' => true, 'body' => 'Second, rewritten'],
+                ],
+            ],
+        ]);
+
+        $this->assertTrue($result['success'], json_encode($result['errors'] ?? []));
+
+        $sets = Entry::find('home')->get('page_builder');
+        $this->assertCount(3, $sets);
+        $this->assertSame(['s1', 's2', 's3'], array_column($sets, 'id'));
+        $this->assertSame('First', $sets[0]['body']);
+        $this->assertSame('Second, rewritten', $sets[1]['body']);
+        $this->assertSame('Third', $sets[2]['body']);
+    }
+
+    public function test_appends_a_set_with_an_unseen_id(): void
+    {
+        $this->makeEntry();
+
+        $result = $this->router->execute([
+            'action' => 'update',
+            'collection' => $this->collectionHandle,
+            'id' => 'home',
+            'merge_sets' => true,
+            'data' => [
+                'page_builder' => [
+                    ['id' => 's4', 'type' => 'cta', 'enabled' => true, 'body' => 'Fourth'],
+                ],
+            ],
+        ]);
+
+        $this->assertTrue($result['success'], json_encode($result['errors'] ?? []));
+        $this->assertSame(['s1', 's2', 's3', 's4'], array_column(Entry::find('home')->get('page_builder'), 'id'));
+    }
+
+    public function test_without_the_flag_the_array_is_still_replaced_wholesale(): void
+    {
+        $this->makeEntry();
+
+        $result = $this->router->execute([
+            'action' => 'update',
+            'collection' => $this->collectionHandle,
+            'id' => 'home',
+            'data' => [
+                'page_builder' => [
+                    ['id' => 's2', 'type' => 'cta', 'enabled' => true, 'body' => 'Only survivor'],
+                ],
+            ],
+        ]);
+
+        $this->assertTrue($result['success'], json_encode($result['errors'] ?? []));
+        $this->assertSame(['s2'], array_column(Entry::find('home')->get('page_builder'), 'id'));
+    }
+
+    public function test_requires_an_id_on_every_item(): void
+    {
+        $this->makeEntry();
+
+        $result = $this->router->execute([
+            'action' => 'update',
+            'collection' => $this->collectionHandle,
+            'id' => 'home',
+            'merge_sets' => true,
+            'data' => ['page_builder' => [['type' => 'cta', 'enabled' => true, 'body' => 'No id']]],
+        ]);
+
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('needs an "id"', implode(' ', $result['errors']));
+        $this->assertCount(3, Entry::find('home')->get('page_builder'));
+    }
+
+    public function test_rejects_a_duplicate_id_within_one_payload(): void
+    {
+        $this->makeEntry();
+
+        $result = $this->router->execute([
+            'action' => 'update',
+            'collection' => $this->collectionHandle,
+            'id' => 'home',
+            'merge_sets' => true,
+            'data' => [
+                'page_builder' => [
+                    ['id' => 's1', 'type' => 'hero', 'enabled' => true, 'body' => 'One'],
+                    ['id' => 's1', 'type' => 'hero', 'enabled' => true, 'body' => 'Two'],
+                ],
+            ],
+        ]);
+
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('more than once', implode(' ', $result['errors']));
+    }
+
+    public function test_leaves_non_replicator_fields_replacing_as_usual(): void
+    {
+        $this->makeEntry();
+
+        $result = $this->router->execute([
+            'action' => 'update',
+            'collection' => $this->collectionHandle,
+            'id' => 'home',
+            'merge_sets' => true,
+            'data' => ['title' => 'Renamed'],
+        ]);
+
+        $this->assertTrue($result['success'], json_encode($result['errors'] ?? []));
+
+        $entry = Entry::find('home');
+        $this->assertSame('Renamed', $entry->get('title'));
+        $this->assertCount(3, $entry->get('page_builder'));
+    }
+}


### PR DESCRIPTION
## Description

A replicator is one blueprint value, so `update` replaces the whole array. Changing one section of a ten-section page builder means reading all ten and sending all ten back.

`merge_sets: true` merges incoming items into the stored array by the `id` every replicator item already carries: an existing id is replaced in place, a new one appended, and stored items the caller did not send are left alone.

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🔧 Tool enhancement
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring

## Related Issue

None — came out of editing one section of a long page builder, where the whole array had to be round-tripped for a one-line change.

## Testing

- [x] Tests pass (`composer test`)
- [x] Code quality checks pass (`composer quality`)
- [x] Tested manually with Statamic

`tests/Feature/Routers/EntriesMergeSetsTest.php` — 6 cases: replace in place, append, full replacement still the default without the flag, missing id, duplicate id, and non-replicator fields unaffected.

Also exercised on a real page builder: merging one section of three left the order intact, changed only that section, and left its neighbours untouched.

Verified against `main`: 4 of the 6 fail there, all pass here.
Full gate green — pint, PHPStan level 9, 1112 tests / 5625 assertions.

### Environment
- Statamic: v6.31.0
- Laravel: v13.30.1
- PHP: 8.4.25

## Checklist

- [x] My code follows the project style
- [x] I've added/updated tests if needed
- [x] Tool responses follow the standard format

## Notes

Addressing by `id` rests on the contract `FieldFormatSpec` already publishes — `item_required_keys: [id, type, enabled]`, unique within the array.

Deliberately narrow: top-level replicator fields only, and replace-or-append only. Removing and reordering stay with a full-array write, where the intent is unambiguous. Bard is excluded because most of its nodes carry no id. Missing and duplicate ids are rejected rather than guessed at.

Off by default, so `update` is unchanged unless asked.