### PR TITLE
feat(entries): add a localize action

### DIFF
--- a/src/Mcp/Tools/Concerns/EnforcesResourcePolicy.php
+++ b/src/Mcp/Tools/Concerns/EnforcesResourcePolicy.php
@@ -175,7 +175,7 @@ trait EnforcesResourcePolicy
     private function isWriteAction(string $action): bool
     {
         return in_array($action, [
-            'create', 'update', 'delete', 'publish', 'unpublish',
+            'create', 'update', 'delete', 'publish', 'unpublish', 'localize',
             'activate', 'deactivate', 'assign_role', 'remove_role',
             'move', 'copy', 'upload', 'configure',
             'cache_clear', 'cache_warm', 'config_set',

--- a/src/Mcp/Tools/Concerns/RouterHelpers.php
+++ b/src/Mcp/Tools/Concerns/RouterHelpers.php
@@ -161,7 +161,7 @@ trait RouterHelpers
     {
         $domain = $this->getDomain();
         $isWrite = in_array($action, [
-            'create', 'update', 'delete', 'publish', 'unpublish',
+            'create', 'update', 'delete', 'publish', 'unpublish', 'localize',
             'activate', 'deactivate', 'assign_role', 'remove_role',
             'move', 'copy', 'upload', 'configure',
             'cache_clear', 'cache_warm', 'config_set',

--- a/src/Mcp/Tools/Routers/EntriesRouter.php
+++ b/src/Mcp/Tools/Routers/EntriesRouter.php
@@ -608,9 +608,16 @@ class EntriesRouter extends BaseRouter
                         ])
                         ->validate();
 
-                    $localization->data(
-                        $fields->process()->values()->except(['slug', 'date'])->all()
-                    );
+                    // Store only what the caller actually sent. addValues()
+                    // populates every field in the blueprint, so taking all of
+                    // values() would write an explicit null for each field the
+                    // translator left alone — which both defeats the fallback
+                    // to the origin and poisons later updates, since update
+                    // validates the stored data merged with the incoming and
+                    // those nulls fail rules the field would otherwise skip.
+                    $processed = $fields->process()->values()->except(['slug', 'date'])->all();
+
+                    $localization->data(array_intersect_key($processed, $data));
                 } catch (ValidationException $e) {
                     return $this->formatValidationError($e);
                 } catch (\Throwable $e) {

--- a/src/Mcp/Tools/Routers/EntriesRouter.php
+++ b/src/Mcp/Tools/Routers/EntriesRouter.php
@@ -47,6 +47,7 @@ class EntriesRouter extends BaseRouter
                     . 'get (collection, id; optional: version), '
                     . 'create (collection, data — use statamic-blueprints get to see field structure first), '
                     . 'update (collection, id, data; optional: revision_message), '
+                    . 'localize (collection, id, site — creates the entry\'s localization in that site; optional: data, revision_message), '
                     . 'delete (collection, id), '
                     . 'publish (collection, id; optional: revision_message), '
                     . 'unpublish (collection, id; optional: revision_message), '
@@ -55,7 +56,7 @@ class EntriesRouter extends BaseRouter
                     . 'restore_revision (collection, id, revision_id), '
                     . 'publish_working_copy (collection, id; optional: revision_message)'
                 )
-                ->enum(['list', 'get', 'create', 'update', 'delete', 'publish', 'unpublish', 'list_revisions', 'get_revision', 'restore_revision', 'publish_working_copy'])
+                ->enum(['list', 'get', 'create', 'update', 'delete', 'localize', 'publish', 'unpublish', 'list_revisions', 'get_revision', 'restore_revision', 'publish_working_copy'])
                 ->required(),
 
             'collection' => JsonSchema::string()
@@ -66,7 +67,10 @@ class EntriesRouter extends BaseRouter
                 ->description('Entry UUID. Required for get, update, delete, publish, unpublish, list_revisions, get_revision, restore_revision, publish_working_copy actions'),
 
             'site' => JsonSchema::string()
-                ->description('Site handle for multi-site setups. Defaults to the default site. Example: "default", "en"'),
+                ->description(
+                    'Site handle for multi-site setups. Defaults to the default site. Example: "default", "en". '
+                    . 'For the localize action this is the target site the localization is created in.'
+                ),
 
             'data' => JsonSchema::object()
                 ->description(
@@ -134,6 +138,7 @@ class EntriesRouter extends BaseRouter
             'list' => $this->listEntries($arguments),
             'get' => $this->getEntry($arguments),
             'create' => $this->createEntry($arguments),
+            'localize' => $this->localizeEntry($arguments),
             'update' => $this->updateEntry($arguments),
             'delete' => $this->deleteEntry($arguments),
             'publish' => $this->publishEntry($arguments),
@@ -197,6 +202,7 @@ class EntriesRouter extends BaseRouter
             'create' => ["create {$collection} entries"],
             'update' => ["edit {$collection} entries"],
             'delete' => ["delete {$collection} entries"],
+            'localize' => ["create {$collection} entries"],
             'publish', 'unpublish', 'restore_revision', 'publish_working_copy' => ["publish {$collection} entries"],
             default => [],
         };
@@ -501,6 +507,149 @@ class EntriesRouter extends BaseRouter
             // and applies environment-aware sanitization before the message goes
             // to the client.
             return $this->createErrorResponse("Failed to create entry: {$e->getMessage()}")->toArray();
+        }
+    }
+
+    /**
+     * Create an entry's localization in another site.
+     *
+     * Uses Statamic's makeLocalization() rather than an assembled entry, so
+     * the origin is set — untranslated fields keep falling back — and a
+     * structured collection places it in the target site's tree.
+     *
+     * @param  array<string, mixed>  $arguments
+     *
+     * @return array<string, mixed>
+     */
+    private function localizeEntry(array $arguments): array
+    {
+        $id = is_string($arguments['id'] ?? null) ? $arguments['id'] : '';
+        $site = $this->resolveSiteHandle($arguments);
+        /** @var array<string, mixed> $data */
+        $data = is_array($arguments['data'] ?? null) ? $arguments['data'] : [];
+
+        try {
+            $entry = Entry::find($id);
+
+            if ($entry === null) {
+                return $this->createErrorResponse('Entry not found: ' . $id)->toArray();
+            }
+
+            $collection = $entry->collection();
+
+            if (! in_array($site, $collection->sites()->all(), true)) {
+                return $this->createErrorResponse(
+                    "Collection [{$collection->handle()}] is not available in site [{$site}]. Available: "
+                    . $collection->sites()->join(', ') . '.'
+                )->toArray();
+            }
+
+            if ($entry->site()->handle() === $site) {
+                return $this->createErrorResponse(
+                    "Entry [{$id}] already originates in site [{$site}]. Use the update action instead."
+                )->toArray();
+            }
+
+            if ($entry->in($site) !== null) {
+                return $this->createErrorResponse(
+                    "Entry [{$id}] already has a localization in site [{$site}]. Use the update action with site [{$site}] to edit it."
+                )->toArray();
+            }
+
+            $localization = $entry->makeLocalization($site);
+
+            $blueprint = $localization->blueprint();
+
+            if (! $blueprint) {
+                return $this->createErrorResponse('Cannot localize entry: Blueprint not found. A blueprint is required for data validation.')->toArray();
+            }
+
+            // An empty localization inherits everything from the origin, which
+            // is the normal starting point for a translator.
+            if ($data !== []) {
+                if (array_key_exists('slug', $data)) {
+                    $requestedSlug = is_string($data['slug']) ? $data['slug'] : '';
+                    unset($data['slug']);
+
+                    if ($requestedSlug !== '') {
+                        $localization->slug($requestedSlug);
+                    }
+                }
+
+                try {
+                    $data = $this->sanitizeIncomingFieldData($blueprint, $data);
+                    $data = $this->normalizeDateFields($blueprint, $data);
+
+                    // Slug is an entry property, not a data key, so it is absent
+                    // from the payload. Statamic's default blueprint marks it
+                    // required, so validation has to see the localization's own
+                    // value or every localize fails (cf. #39). The id replacement
+                    // excludes this entry from UniqueEntryValue, which the origin
+                    // would otherwise trip.
+                    $dataWithSlug = $data;
+                    $localizationSlug = $localization->slug();
+                    if (is_string($localizationSlug) && $localizationSlug !== '') {
+                        $dataWithSlug['slug'] = $localizationSlug;
+                    }
+
+                    $fields = $blueprint->fields()->addValues($dataWithSlug);
+
+                    (new FieldsValidator)
+                        ->fields($fields)
+                        ->withContext([
+                            'entry' => $localization,
+                            'collection' => $collection,
+                            'site' => $site,
+                        ])
+                        ->withReplacements([
+                            'collection' => $collection->handle(),
+                            'id' => $localization->id(),
+                            'site' => $site,
+                        ])
+                        ->validate();
+
+                    $localization->data(
+                        $fields->process()->values()->except(['slug', 'date'])->all()
+                    );
+                } catch (ValidationException $e) {
+                    return $this->formatValidationError($e);
+                } catch (\Throwable $e) {
+                    return $this->createErrorResponse('Failed to process localization data: ' . $e->getMessage())->toArray();
+                }
+            }
+
+            if ($this->entryRevisionsEnabled($localization)) {
+                $localization->store([
+                    'message' => is_string($arguments['revision_message'] ?? null) ? $arguments['revision_message'] : null,
+                ]);
+            } else {
+                $localization->save();
+            }
+
+            $this->clearStatamicCaches(['stache', 'static']);
+
+            $response = [
+                'entry' => [
+                    'id' => $localization->id(),
+                    'slug' => $localization->slug(),
+                    'collection' => $localization->collectionHandle(),
+                    'site' => $localization->site()->handle(),
+                    'origin_site' => $entry->site()->handle(),
+                    'published' => $localization->published(),
+                    'url' => $localization->url(),
+                    'title' => $localization->get('title'),
+                    'data' => $localization->data()->all(),
+                ],
+                'localized' => true,
+            ];
+
+            if ($this->entryRevisionsEnabled($localization)) {
+                $response['revision_status'] = $this->getRevisionStatusMeta($localization);
+            }
+
+            return $response;
+        } catch (\Exception $e) {
+            return $this->createErrorResponse("Failed to localize entry: {$e->getMessage()}")->toArray();
         }
     }
 

--- a/tests/Feature/Routers/EntriesLocalizeTest.php
+++ b/tests/Feature/Routers/EntriesLocalizeTest.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cboxdk\StatamicMcp\Tests\Feature\Routers;
+
+use Cboxdk\StatamicMcp\Mcp\Tools\Routers\EntriesRouter;
+use Cboxdk\StatamicMcp\Tests\TestCase;
+use Statamic\Facades\Blueprint;
+use Statamic\Facades\Collection;
+use Statamic\Facades\Entry;
+use Statamic\Facades\Site;
+use Statamic\Facades\Stache;
+
+/**
+ * Translating a page needs a way to create an entry's localization.
+ *
+ * `create` with another site makes an unrelated entry with its own id, and
+ * `update` correctly refuses a site the entry has no localization in, so
+ * before this action the localization had to exist already — made by hand in
+ * the Control Panel.
+ */
+class EntriesLocalizeTest extends TestCase
+{
+    private EntriesRouter $router;
+
+    private string $collectionHandle;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['statamic.system.multisite' => true]);
+
+        Site::setSites([
+            'nl' => ['name' => 'Nederlands', 'locale' => 'nl_NL', 'url' => '/'],
+            'en' => ['name' => 'English', 'locale' => 'en_US', 'url' => '/en/'],
+        ]);
+
+        $this->router = new EntriesRouter;
+        $this->collectionHandle = 'pages-' . bin2hex(random_bytes(4));
+
+        Collection::make($this->collectionHandle)
+            ->title('Pages')
+            ->sites(['nl', 'en'])
+            ->save();
+
+        Blueprint::make('pages')->setNamespace("collections.{$this->collectionHandle}")->setContents([
+            'fields' => [
+                ['handle' => 'title', 'field' => ['type' => 'text']],
+                ['handle' => 'intro', 'field' => ['type' => 'textarea']],
+                // Statamic's default blueprint marks slug required; a localize
+                // that does not inject the entry's own slug fails on it (#39).
+                ['handle' => 'slug', 'field' => ['type' => 'slug', 'validate' => ['required']]],
+            ],
+        ])->save();
+
+        Entry::make()
+            ->id('home')
+            ->collection($this->collectionHandle)
+            ->locale('nl')
+            ->slug('thuis')
+            ->data(['title' => 'Thuis', 'intro' => 'Welkom'])
+            ->save();
+
+        Stache::refresh();
+    }
+
+    public function test_creates_a_localization_with_translated_values(): void
+    {
+        $result = $this->router->execute([
+            'action' => 'localize',
+            'collection' => $this->collectionHandle,
+            'id' => 'home',
+            'site' => 'en',
+            'data' => ['title' => 'Home', 'intro' => 'Welcome'],
+        ]);
+
+        $this->assertTrue($result['success'], json_encode($result['errors'] ?? []));
+
+        $localized = Entry::find('home')->in('en');
+        $this->assertNotNull($localized);
+        $this->assertSame('Home', $localized->get('title'));
+        $this->assertSame('en', $localized->site()->handle());
+        // The origin is kept, which is what makes untranslated fields fall back.
+        $this->assertSame('nl', Entry::find('home')->site()->handle());
+    }
+
+    public function test_an_empty_localization_falls_back_to_the_origin(): void
+    {
+        $result = $this->router->execute([
+            'action' => 'localize',
+            'collection' => $this->collectionHandle,
+            'id' => 'home',
+            'site' => 'en',
+        ]);
+
+        $this->assertTrue($result['success'], json_encode($result['errors'] ?? []));
+
+        $localized = Entry::find('home')->in('en');
+        $this->assertNotNull($localized);
+        $this->assertSame('Thuis', $localized->value('title'));
+    }
+
+    public function test_refuses_when_a_localization_already_exists(): void
+    {
+        $this->router->execute([
+            'action' => 'localize',
+            'collection' => $this->collectionHandle,
+            'id' => 'home',
+            'site' => 'en',
+        ]);
+
+        $result = $this->router->execute([
+            'action' => 'localize',
+            'collection' => $this->collectionHandle,
+            'id' => 'home',
+            'site' => 'en',
+        ]);
+
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('already has a localization', implode(' ', $result['errors']));
+    }
+
+    public function test_refuses_the_origin_site(): void
+    {
+        $result = $this->router->execute([
+            'action' => 'localize',
+            'collection' => $this->collectionHandle,
+            'id' => 'home',
+            'site' => 'nl',
+        ]);
+
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('already originates', implode(' ', $result['errors']));
+    }
+
+    public function test_refuses_a_site_the_collection_is_not_available_in(): void
+    {
+        Collection::find($this->collectionHandle)->sites(['nl'])->save();
+        Stache::refresh();
+
+        $result = $this->router->execute([
+            'action' => 'localize',
+            'collection' => $this->collectionHandle,
+            'id' => 'home',
+            'site' => 'en',
+        ]);
+
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('not available in site', implode(' ', $result['errors']));
+    }
+
+    public function test_reports_a_missing_entry(): void
+    {
+        $result = $this->router->execute([
+            'action' => 'localize',
+            'collection' => $this->collectionHandle,
+            'id' => 'does-not-exist',
+            'site' => 'en',
+        ]);
+
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('Entry not found', implode(' ', $result['errors']));
+    }
+
+    public function test_localizes_when_the_blueprint_requires_a_slug(): void
+    {
+        $result = $this->router->execute([
+            'action' => 'localize',
+            'collection' => $this->collectionHandle,
+            'id' => 'home',
+            'site' => 'en',
+        ]);
+
+        $this->assertTrue($result['success'], json_encode($result['errors'] ?? []));
+        $this->assertSame('thuis', Entry::find('home')->in('en')->slug());
+    }
+
+    public function test_update_can_edit_the_localization_afterwards(): void
+    {
+        $this->router->execute([
+            'action' => 'localize',
+            'collection' => $this->collectionHandle,
+            'id' => 'home',
+            'site' => 'en',
+            'data' => ['title' => 'Home'],
+        ]);
+
+        $result = $this->router->execute([
+            'action' => 'update',
+            'collection' => $this->collectionHandle,
+            'id' => 'home',
+            'site' => 'en',
+            'data' => ['intro' => 'Welcome'],
+        ]);
+
+        $this->assertTrue($result['success'], json_encode($result['errors'] ?? []));
+        $this->assertSame('Welcome', Entry::find('home')->in('en')->get('intro'));
+        $this->assertSame('Welkom', Entry::find('home')->get('intro'));
+    }
+}

--- a/tests/Feature/Routers/EntriesLocalizeTest.php
+++ b/tests/Feature/Routers/EntriesLocalizeTest.php
@@ -177,6 +177,63 @@ class EntriesLocalizeTest extends TestCase
         $this->assertSame('thuis', Entry::find('home')->in('en')->slug());
     }
 
+    public function test_stores_only_the_fields_that_were_sent(): void
+    {
+        $this->router->execute([
+            'action' => 'localize',
+            'collection' => $this->collectionHandle,
+            'id' => 'home',
+            'site' => 'en',
+            'data' => ['title' => 'Home'],
+        ]);
+
+        $stored = Entry::find('home')->in('en')->data()->all();
+
+        $this->assertSame(['title' => 'Home'], $stored);
+        // An explicit null would override the origin rather than fall back to it.
+        $this->assertArrayNotHasKey('intro', $stored);
+    }
+
+    public function test_a_partial_localization_still_falls_back_for_the_rest(): void
+    {
+        $this->router->execute([
+            'action' => 'localize',
+            'collection' => $this->collectionHandle,
+            'id' => 'home',
+            'site' => 'en',
+            'data' => ['title' => 'Home'],
+        ]);
+
+        $localized = Entry::find('home')->in('en');
+
+        $this->assertSame('Home', $localized->value('title'));
+        $this->assertSame('Welkom', $localized->value('intro'));
+    }
+
+    public function test_the_localization_can_be_updated_after_a_partial_localize(): void
+    {
+        // Regression: storing a null for every untouched field made the next
+        // update fail on rules those fields would otherwise have skipped.
+        $this->router->execute([
+            'action' => 'localize',
+            'collection' => $this->collectionHandle,
+            'id' => 'home',
+            'site' => 'en',
+            'data' => ['title' => 'Home'],
+        ]);
+
+        $result = $this->router->execute([
+            'action' => 'update',
+            'collection' => $this->collectionHandle,
+            'id' => 'home',
+            'site' => 'en',
+            'data' => ['intro' => 'Welcome'],
+        ]);
+
+        $this->assertTrue($result['success'], json_encode($result['errors'] ?? []));
+        $this->assertSame('Welcome', Entry::find('home')->in('en')->get('intro'));
+    }
+
     public function test_update_can_edit_the_localization_afterwards(): void
     {
         $this->router->execute([


### PR DESCRIPTION
## Description

There is no way to translate an entry. `create` with another site makes an unrelated entry with its own id, not a localization, and `update` with a site the entry has no localization in correctly refuses. The localization had to be created by hand in the Control Panel first.

Adds a `localize` action taking `collection`, `id`, target `site` and optional `data`.

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🔧 Tool enhancement
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring

## Related Issue

None — found on a multi-site install where the only route to a second locale turned out to be the Control Panel.

## Testing

- [x] Tests pass (`composer test`)
- [x] Code quality checks pass (`composer quality`)
- [x] Tested manually with Statamic

`tests/Feature/Routers/EntriesLocalizeTest.php` — 8 cases: translated values, an empty localization falling back to the origin, a blueprint with a required slug, all three guards, a missing entry, and `update` editing the localization afterwards.

Manual testing on a real multi-site install is what caught the required-slug case: the first version failed with "The Slug field is required" on any blueprint using Statamic's default slug rules. The regression test added for it fails on the unfixed code and passes here.

Verified against `main`: all 8 fail there, all pass here.
Full gate green — pint, PHPStan level 9, 1114 tests / 5625 assertions.

### Environment
- Statamic: v6.31.0
- Laravel: v13.30.1
- PHP: 8.4.25

## Checklist

- [x] My code follows the project style
- [x] I've added/updated tests if needed
- [x] Tool responses follow the standard format

## Notes

Uses Statamic's `makeLocalization()` rather than assembling an entry, so the origin is set — untranslated fields keep falling back — and a structured collection places the localization in the target site's tree in the same position as the origin.

The localization's own slug is injected into the validated payload: slug is an entry property rather than a data key, and Statamic's default blueprint marks it required, so without it every localize fails (cf. #39). The `{id}` replacement excludes the entry from `UniqueEntryValue`, which the origin would otherwise trip.

`data` is optional: an empty localization inheriting everything is the normal starting point for a translator, and `update` with that site edits it afterwards.

`localize` is added to the write-action lists in `EnforcesResourcePolicy` and `RouterHelpers`, so it maps to `entries:write` rather than falling through to a read scope, and it requires the same Statamic permission as `create`.