### PR TITLE
fix(format-spec): read every option shape a select can be written in

### DIFF
--- a/src/Mcp/Support/FieldFormatSpec.php
+++ b/src/Mcp/Support/FieldFormatSpec.php
@@ -368,19 +368,53 @@ class FieldFormatSpec
     {
         $config = $field->config();
         $multiple = (bool) ($config['multiple'] ?? false);
-        $rawOptions = $config['options'] ?? [];
-        $options = [];
-        if (is_array($rawOptions)) {
-            // Statamic options can be either a flat list or a key=>label map.
-            $isAssoc = array_keys($rawOptions) !== range(0, count($rawOptions) - 1);
-            $options = $isAssoc ? array_keys($rawOptions) : array_values(array_filter($rawOptions, 'is_scalar'));
-        }
 
         return [
             'wire_format' => $multiple ? 'array' : 'string',
             'shape' => $multiple ? 'enum_array' : 'enum',
-            'allowed_values' => array_map(static fn ($v): string => (string) $v, $options),
+            'allowed_values' => $this->optionValues($config['options'] ?? []),
         ];
+    }
+
+    /**
+     * The writable value of each option, across the three shapes Statamic
+     * accepts (see Fieldtypes\HasSelectOptions::getOptions()): a key => label
+     * map, a flat list of scalars, and a list of ['key' => ..., 'value' => ...]
+     * maps. The last is what the Control Panel writes, so it is the common one
+     * in practice.
+     *
+     * @return list<string>
+     */
+    private function optionValues(mixed $options): array
+    {
+        if ($options instanceof Collection) {
+            $options = $options->all();
+        }
+
+        if (! is_array($options)) {
+            return [];
+        }
+
+        $values = [];
+
+        foreach ($options as $key => $option) {
+            if (is_array($option)) {
+                if (array_key_exists('key', $option) && is_scalar($option['key'])) {
+                    $values[] = $option['key'];
+                }
+
+                continue;
+            }
+
+            // A string key means a key => label map; otherwise it is a flat list.
+            $candidate = is_string($key) ? $key : $option;
+
+            if (is_scalar($candidate)) {
+                $values[] = $candidate;
+            }
+        }
+
+        return array_map(static fn (mixed $v): string => (string) $v, $values);
     }
 
     /**

--- a/tests/Unit/FieldFormatSpecTest.php
+++ b/tests/Unit/FieldFormatSpecTest.php
@@ -199,3 +199,52 @@ it('returns null for unknown fieldtypes so the response stays small', function (
 
     expect($spec)->toBeNull();
 });
+
+it('reads options written as a list of key/value maps', function (): void {
+    // What the Control Panel writes, and what selectSpec used to drop entirely.
+    $spec = (new FieldFormatSpec)->for(makeField('select', ['options' => [
+        ['key' => 'solid', 'value' => 'Solid Header'],
+        ['key' => 'transparent', 'value' => 'Transparent Header'],
+    ]]));
+
+    expect($spec['allowed_values'])->toBe(['solid', 'transparent']);
+});
+
+it('reads options written as a key to label map', function (): void {
+    $spec = (new FieldFormatSpec)->for(makeField('button_group', ['options' => [
+        'grid' => 'Grid',
+        'carousel' => 'Carousel',
+    ]]));
+
+    expect($spec['allowed_values'])->toBe(['grid', 'carousel']);
+});
+
+it('reads options written as a flat list', function (): void {
+    $spec = (new FieldFormatSpec)->for(makeField('radio', ['options' => ['left', 'center']]));
+
+    expect($spec['allowed_values'])->toBe(['left', 'center']);
+});
+
+it('casts non-string option keys to strings', function (): void {
+    $spec = (new FieldFormatSpec)->for(makeField('select', ['options' => [
+        ['key' => 1, 'value' => 'One'],
+        ['key' => 2, 'value' => 'Two'],
+    ]]));
+
+    expect($spec['allowed_values'])->toBe(['1', '2']);
+});
+
+it('returns no allowed values when a select has no options', function (): void {
+    expect((new FieldFormatSpec)->for(makeField('select'))['allowed_values'])->toBe([]);
+});
+
+it('still reports enum_array for a multiple select', function (): void {
+    $spec = (new FieldFormatSpec)->for(makeField('select', [
+        'multiple' => true,
+        'options' => [['key' => 'a', 'value' => 'A']],
+    ]));
+
+    expect($spec['wire_format'])->toBe('array');
+    expect($spec['shape'])->toBe('enum_array');
+    expect($spec['allowed_values'])->toBe(['a']);
+});


### PR DESCRIPTION
## Description

`selectSpec()` handled two of the three option shapes Statamic accepts: a `key => label` map and a flat list of scalars. It missed the list of `['key' => ..., 'value' => ...]` maps, which is what the Control Panel writes and therefore the common one in practice. Those entries are arrays under numeric keys, so the `is_scalar` filter dropped them all and `allowed_values` came back empty.

Mirrors `Fieldtypes\HasSelectOptions::getOptions()` so all three shapes resolve.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔧 Tool enhancement
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring

## Related Issue

None. Found writing a page-builder entry, where every `select` and `button_group` in the blueprint reported `"allowed_values": []` while the field config alongside it carried the options in full.

## Testing

- [x] Tests pass (`composer test`)
- [x] Code quality checks pass (`composer quality`)
- [x] Tested manually with Statamic

`tests/Unit/FieldFormatSpecTest.php` — 6 cases: each of the three shapes, a non-string key cast to string, a select with no options, and `enum_array` still reported for a multiple select.

Verified against `main`: 3 of the 6 fail there, all pass here. The other 3 are regression guards for the two shapes that already worked.

Full gate green — pint, PHPStan level 9, 1112 tests / 5611 assertions.

### Environment
- Statamic: v6.31.0
- Laravel: v13.30.1
- PHP: 8.4.25

## Checklist

- [x] My code follows the project style
- [x] I've added/updated tests if needed
- [x] Tool responses follow the standard format

## Notes

The effect is worse than one empty array: a client sees a field it knows is an enum with nothing to choose from, so it either guesses or omits the field. On a `select` driving a template branch, omitting it renders nothing, and the write still reports success.

Two things deliberately left out of scope. `cast_booleans` selects store real booleans rather than the string values reported here, which the spec does not yet express. And the option *labels* are dropped, though they would help a client choose between values it cannot otherwise interpret. 